### PR TITLE
chore: create activities audit log table in DuckDB

### DIFF
--- a/src/migrations/0007_create_activities_table.py
+++ b/src/migrations/0007_create_activities_table.py
@@ -1,0 +1,43 @@
+"""
+Migration create_activities_table
+
+Audit log for all meaningful farm actions.
+
+monetary_value and cost_centre are nullable now farmdb EE will populate
+them for profitability reporting without a breaking schema change.
+"""
+
+import duckdb
+
+
+def up(conn: duckdb.DuckDBPyConnection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS v1.activities (
+            id             TEXT         PRIMARY KEY,
+            actor_id       TEXT         NOT NULL,
+            actor_email    TEXT         NOT NULL,
+            action         TEXT         NOT NULL,
+            entity_type    TEXT         NOT NULL,
+            entity_id      TEXT         NOT NULL,
+            description    TEXT         NOT NULL,
+            metadata       JSON,
+            monetary_value DECIMAL(12, 4),
+            cost_centre    TEXT,
+            created_at     TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_activities_actor_id
+        ON v1.activities(actor_id)
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_activities_entity
+        ON v1.activities(entity_type, entity_id)
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_activities_action
+        ON v1.activities(action)
+    """)


### PR DESCRIPTION
Description

Every meaningful farm action needs an audit trail. This table is the
foundation for WKLM-51 (crop creation) and every future feature that
mutates farm state.

Schema decisions

- actor_id and actor_email , id is the stable FK email is captured
 at write time so the audit trail remains accurate after email changes.

- action uses dot-notation like crop.creatednamespaced, filterable,
 machine-readable, consistent across all future entities.

- entity_type and entity_id ,generic enough to cover every future
entity such as fields, harvests, inputs without schema changes.

- metadata JSON ,captures a full snapshot at time of action so farmdb
EE can reconstruct profitability without additional queries.

- monetary_value and cost_centre ,nullable now, populated by farmdb
EE only. Adding them now means zero breaking migrations when EE lands.

No updated_at activities are immutable. An audit log row is never edited.

Three indexes on actor_id, entity_type and entity_id together, and action
covering the most common query patterns.

https://carbonbits-ke.atlassian.net/browse/WKLM-54

Dependencies
WKLM-51 crop creation will be the first consumer of this table.
Designed to serve all future farm state mutations not just crops.