### PR TITLE
chore(CI): Implemented a full GitOps release path

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -20,8 +20,12 @@ jobs:
       - name: Decode private key
         id: decode-key
         run: |
-          private_key=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)
-          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+          private_key=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d)
+          {
+            echo "private-key<<EOF"
+            echo "$private_key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -20,17 +20,15 @@ jobs:
       - name: Decode private key
         id: decode-key
         run: |
-          KEY=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d)
-          echo "DECODED_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
-          echo "$KEY" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          private_key=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)
+          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ env.DECODED_PRIVATE_KEY }}
+          client-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ steps.decode-key.outputs.private-key }}
 
       - uses: actions/checkout@v6
         with:
@@ -52,6 +50,16 @@ jobs:
     needs: release
     if: needs.release.outputs.released == 'true' && github.event.repository.visibility == 'public'
     uses: ./.github/workflows/docker-publish.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit
+
+  infra-charts:
+    needs:
+      - release
+      - docker
+    if: needs.release.outputs.released == 'true' && github.event.repository.visibility == 'public'
+    uses: ./.github/workflows/update-infra-charts.yml
     with:
       version: ${{ needs.release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/update-infra-charts.yml
+++ b/.github/workflows/update-infra-charts.yml
@@ -1,0 +1,83 @@
+name: Update infra-charts
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      infra_charts_ref:
+        required: false
+        type: string
+        default: main
+      infra_charts_path:
+        required: false
+        type: string
+        default: charts/farmdb
+
+permissions:
+  contents: read
+
+jobs:
+  update-infra-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode private key
+        id: decode-key
+        run: |
+          private_key=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)
+          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ steps.decode-key.outputs.private-key }}
+          owner: carbonbits
+          repositories: infra-charts
+
+      - name: Checkout farmdb
+        uses: actions/checkout@v6
+        with:
+          path: farmdb
+
+      - name: Checkout infra-charts
+        uses: actions/checkout@v6
+        with:
+          repository: carbonbits/infra-charts
+          ref: ${{ inputs.infra_charts_ref }}
+          path: infra-charts
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Update chart contents
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET_PATH: ${{ inputs.infra_charts_path }}
+        run: |
+          mkdir -p "infra-charts/$TARGET_PATH"
+          rm -rf "infra-charts/$TARGET_PATH"/*
+          cp -R farmdb/k8s/helm/farmdb/. "infra-charts/$TARGET_PATH/"
+
+          sed -i "s/^version: .*/version: ${VERSION}/" "infra-charts/$TARGET_PATH/Chart.yaml"
+          sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" "infra-charts/$TARGET_PATH/Chart.yaml"
+          sed -i "s/^  tag: .*/  tag: \"${VERSION}\"/" "infra-charts/$TARGET_PATH/values.yaml"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: infra-charts
+          commit-message: "chore(farmdb): bump chart to ${{ inputs.version }}"
+          branch: chore/farmdb-${{ inputs.version }}
+          delete-branch: true
+          title: "chore(farmdb): release ${{ inputs.version }}"
+          body: |
+            Automated chart sync from carbonbits/farmdb.
+
+            - Updates Helm chart in `${{ inputs.infra_charts_path }}`
+            - Sets chart `version` and `appVersion` to `${{ inputs.version }}`
+            - Sets image tag to `${{ inputs.version }}`
+          labels: |
+            automation
+            release

--- a/.github/workflows/update-infra-charts.yml
+++ b/.github/workflows/update-infra-charts.yml
@@ -66,6 +66,7 @@ jobs:
           sed -i "s/^version: .*/version: ${VERSION}/" "infra-charts/$TARGET_PATH/Chart.yaml"
           sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" "infra-charts/$TARGET_PATH/Chart.yaml"
           sed -i "s/^  tag: .*/  tag: \"${VERSION}\"/" "infra-charts/$TARGET_PATH/values.yaml"
+          sed -i "s/^  tag: .*/  tag: \"${VERSION}\"/" "infra-charts/$TARGET_PATH/values-prod.yaml"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/update-infra-charts.yml
+++ b/.github/workflows/update-infra-charts.yml
@@ -60,7 +60,7 @@ jobs:
           TARGET_PATH: ${{ inputs.infra_charts_path }}
         run: |
           mkdir -p "infra-charts/$TARGET_PATH"
-          rm -rf "infra-charts/$TARGET_PATH"/*
+          find "infra-charts/$TARGET_PATH" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
           cp -R farmdb/k8s/helm/farmdb/. "infra-charts/$TARGET_PATH/"
 
           sed -i "s/^version: .*/version: ${VERSION}/" "infra-charts/$TARGET_PATH/Chart.yaml"

--- a/.github/workflows/update-infra-charts.yml
+++ b/.github/workflows/update-infra-charts.yml
@@ -25,8 +25,12 @@ jobs:
       - name: Decode private key
         id: decode-key
         run: |
-          private_key=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)
-          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+          private_key=$(echo "${{ secrets.GH_APP_PRIVATE_KEY }}" | base64 -d)
+          {
+            echo "private-key<<EOF"
+            echo "$private_key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
         id: app-token

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ farmdb.egg-info
 .env
 
 *.tar
+/venv

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,27 @@
+# Kubernetes deployment
+
+This repository ships a Helm chart in `k8s/helm/farmdb` and an Argo CD Application manifest in `k8s/argocd/farmdb-application.yaml`.
+
+## Release flow
+
+1. `semantic-release` creates a new version.
+2. Docker image `carbonbitshq/farmdb:<version>` is published.
+3. Workflow `update-infra-charts.yml` copies this chart to `carbonbits/infra-charts` and opens a PR with:
+   - updated chart `version`
+   - updated chart `appVersion`
+   - updated image `tag`
+4. After the PR is merged in `infra-charts`, Argo CD syncs and deploys the new release.
+
+## Required GitHub settings
+
+- Secret `GH_APP_PRIVATE_KEY` (base64 encoded private key)
+- Secret `GH_APP_ID` (GitHub App client id)
+- The GitHub App must have access to both:
+  - `carbonbits/farmdb`
+  - `carbonbits/infra-charts`
+
+## Apply Argo CD application
+
+```bash
+kubectl apply -f k8s/argocd/farmdb-application.yaml
+```

--- a/k8s/argocd/farmdb-application.yaml
+++ b/k8s/argocd/farmdb-application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: farmdb
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/carbonbits/infra-charts.git
+    targetRevision: main
+    path: charts/farmdb
+    helm:
+      releaseName: farmdb
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: farmdb
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/helm/farmdb/Chart.yaml
+++ b/k8s/helm/farmdb/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: farmdb
+description: Helm chart for deploying the FarmDB service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/k8s/helm/farmdb/templates/NOTES.txt
+++ b/k8s/helm/farmdb/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+  http{{ if .Values.ingress.tls }}s{{ end }}://{{ (index .Values.ingress.hosts 0).host }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "farmdb.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  kubectl get --namespace {{ .Release.Namespace }} svc/{{ include "farmdb.fullname" . }} -w
+{{- else }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "farmdb.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/k8s/helm/farmdb/templates/_helpers.tpl
+++ b/k8s/helm/farmdb/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* Expand the name of the chart. */}}
+{{- define "farmdb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create a default fully qualified app name. */}}
+{{- define "farmdb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Chart label */}}
+{{- define "farmdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "farmdb.labels" -}}
+helm.sh/chart: {{ include "farmdb.chart" . }}
+{{ include "farmdb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "farmdb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "farmdb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Service account name */}}
+{{- define "farmdb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "farmdb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/farmdb/templates/deployment.yaml
+++ b/k8s/helm/farmdb/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "farmdb.fullname" . }}
+  labels:
+    {{- include "farmdb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "farmdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "farmdb.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "farmdb.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/helm/farmdb/templates/hpa.yaml
+++ b/k8s/helm/farmdb/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "farmdb.fullname" . }}
+  labels:
+    {{- include "farmdb.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "farmdb.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/k8s/helm/farmdb/templates/ingress.yaml
+++ b/k8s/helm/farmdb/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "farmdb.fullname" . }}
+  labels:
+    {{- include "farmdb.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "farmdb.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/helm/farmdb/templates/service.yaml
+++ b/k8s/helm/farmdb/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "farmdb.fullname" . }}
+  labels:
+    {{- include "farmdb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "farmdb.selectorLabels" . | nindent 4 }}

--- a/k8s/helm/farmdb/templates/serviceaccount.yaml
+++ b/k8s/helm/farmdb/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "farmdb.serviceAccountName" . }}
+  labels:
+    {{- include "farmdb.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/k8s/helm/farmdb/values-prod.yaml
+++ b/k8s/helm/farmdb/values-prod.yaml
@@ -3,7 +3,7 @@ replicaCount: 2
 image:
   repository: carbonbitshq/farmdb
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: ""
 
 ingress:
   enabled: true

--- a/k8s/helm/farmdb/values-prod.yaml
+++ b/k8s/helm/farmdb/values-prod.yaml
@@ -1,0 +1,31 @@
+replicaCount: 2
+
+image:
+  repository: carbonbitshq/farmdb
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: farmdb.carbonbits.work
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70

--- a/k8s/helm/farmdb/values.yaml
+++ b/k8s/helm/farmdb/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: carbonbitshq/farmdb
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/k8s/helm/farmdb/values.yaml
+++ b/k8s/helm/farmdb/values.yaml
@@ -1,0 +1,76 @@
+replicaCount: 1
+
+image:
+  repository: carbonbitshq/farmdb
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 5700
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: farmdb.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /openapi.json
+    port: http
+readinessProbe:
+  httpGet:
+    path: /openapi.json
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+env: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
**Helm chart created** 

Uses path `charts/farmdb`

Enables automated sync, prune, self-heal, and namespace creation

Triggered via workflow_call with released version input

Checks out both repos

Copies this repo chart into infra-charts path

Bumps Chart version, appVersion, and image tag to release version

Opens PR in `carbonbits/infra-charts` using GitHub App token

Added infra-charts job after release and docker jobs

Only runs when a release is actually published