### PR TITLE
feat(docker): add docker-compose distribution for self-hosted deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 JWT_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+JWT_SECRET_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@ WORKDIR /app
 COPY --chown=mkulima:shamba pyproject.toml uv.lock README.md ./
 COPY --chown=mkulima:shamba src/ ./src/
 COPY --from=web-builder --chown=mkulima:shamba /web/out ./src/apps/web/out
+COPY --chown=mkulima:shamba docker-entrypoint.sh ./
 
-RUN uv sync --frozen --no-dev && chown -R mkulima:shamba /app
+RUN uv sync --frozen --no-dev && mkdir -p /app/data && chown -R mkulima:shamba /app && chmod +x docker-entrypoint.sh
 
 USER mkulima
 ENV PYTHONPATH=/app/src
 
 EXPOSE 5700
 
-CMD ["uv", "run", "src/main.py"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 Manage your farm professionally
 
+### Run with Docker Compose
+
+```bash
+cp .env.example .env
+python -c "import secrets; print(secrets.token_urlsafe(32))"  # paste the output into JWT_SECRET_KEY in .env
+docker compose up
+```
+
+Open [http://localhost:5700](http://localhost:5700). Migrations run automatically on
+startup; the DuckDB file persists in a named volume across restarts.
+
 ### Migrations
 Example
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Manage your farm professionally
 
 ```bash
 cp .env.example .env
-python -c "import secrets; print(secrets.token_urlsafe(32))"  # paste the output into JWT_SECRET_KEY in .env
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"  # paste the output into JWT_SECRET_KEY in .env
 docker compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  farmdb:
+    image: carbonbitshq/farmdb:latest
+    # Uncomment to build from source instead of the published image:
+    # build: .
+    ports:
+      - "5700:5700"
+    volumes:
+      - farmdb-data:/app/data
+    env_file:
+      - .env
+    environment:
+      - DATABASE_PATH=/app/data/farm.db
+
+volumes:
+  farmdb-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   farmdb:
-    image: carbonbitshq/farmdb:latest
+    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-latest}
     # Uncomment to build from source instead of the published image:
     # build: .
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
 
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
 uv run --frozen --no-dev farmdb migration apply
 exec uv run --frozen --no-dev src/main.py

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+uv run --frozen --no-dev farmdb migration apply
+exec uv run --frozen --no-dev src/main.py


### PR DESCRIPTION
## What

Adds `docker-compose.yml`, `docker-entrypoint.sh`, and `.env.example` so a self-hosted operator can run `docker compose up` and get a working farmdb instance, per the Free-tier goal in the Business model & tiers doc ("anyone can `docker compose up` in under 10 minutes", Confluence CEN-73793726).

## How

- `docker-compose.yml`: single service pointing at the already-published `carbonbitshq/farmdb:latest` image (built by `.github/workflows/docker-publish.yml`), with a commented `build: .` alternative, a named volume for the DuckDB file, and `.env` for secrets. No new services to orchestrate — the existing Dockerfile already builds frontend + API into one image.
- `docker-entrypoint.sh` + `Dockerfile`: runs `uv run --frozen --no-dev farmdb migration apply` before starting the server. Without this, a fresh `docker compose up` would boot into an unmigrated, unusable database — migrations were previously a manual step. Also creates `/app/data` with correct ownership in the image so the volume mount doesn't end up root-owned and unwritable by the non-root container user.
- `.env.example`: documents the one required secret, `JWT_SECRET_KEY` (`src/config/settings.py` otherwise generates a fresh one on every process start, which would invalidate all sessions on every container restart).
- `README.md`: short "Run with Docker Compose" section.

**Tier-agnostic by design**: nothing here special-cases the Free tier. `AUTHZ_DRIVER` (local vs. platform/Enterprise, see `src/core/authz/`) and any future license-key env var are additive via the same `.env` — Enterprise self-hosted uses the same image, same compose file, no separate install path, matching "same UI/components... unlocked by a license key, not a different install process."

Caught and fixed one bug during verification: the entrypoint's initial version triggered a runtime re-download of dev dependencies (`ruff`, `virtualenv`) on every boot because `uv run` didn't match the build's `--frozen --no-dev` flags — fixed by passing the same flags at runtime.

## Test plan

- [x] Built from source (`docker compose up --build`) on a clean checkout with no prior volume
- [x] Confirmed all 11 migrations run automatically on first boot (checked container logs)
- [x] Landing page (`/`) and `/docs` return 200
- [x] Registered an account via `/v1/auth/register`
- [x] Full `docker compose down && docker compose up` (not just a container restart) — confirmed no re-migration needed (volume persisted) and login still works with the same account (JWT secret persisted via `.env`)
- [x] `git diff` confirms no changes outside packaging files — `src/` untouched

Refs: WKLM-104