### PR TITLE
fix(web): repair invalid JSX in sidebar settings button

### DIFF
--- a/src/apps/web/components/sidebar/index.tsx
+++ b/src/apps/web/components/sidebar/index.tsx
@@ -89,7 +89,9 @@ export function Sidebar() {
 							type="button"
 							aria-label="Settings"
 							className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[#C8BA9F] hover:bg-white/5 hover:text-[#EADFCB]"
+						>
 							<Settings size={16} aria-hidden="true" />
+						</button>
 					)}
 				</div>
 			</div>


### PR DESCRIPTION
## What

**master is currently broken** — the Semantic Release Docker image build has been failing since the WKLM-72 merge (https://github.com/carbonbits/farmdb/actions/runs/29849276288/job/88697933915), so no new release image can ship.

## How

Commit `6fbcbb6` ("Potential fix for pull request finding", a GitHub Copilot Autofix suggestion accepted on the WKLM-72 branch before merge) produced invalid JSX in `components/sidebar/index.tsx`: it dropped the button's closing `>` and the `</button>` tag while adding `aria-hidden` to the icon. The Lint and Test CI checks don't run `next build`, so this reached `master` undetected — only the post-merge Docker publish job caught it.

Restores valid JSX:
```tsx
<button
  type="button"
  aria-label="Settings"
  className="..."
>
  <Settings size={16} aria-hidden="true" />
</button>
```
Kept the `aria-hidden="true"` addition — reasonable on its own, since the button already carries `aria-label="Settings"` and the icon shouldn't be double-announced by screen readers. (Checked the other Copilot Autofix commit on that branch too, `15c04a0` on `nav-item.tsx` — that one's clean, just adds `aria-label`/`aria-current`, no issue.)

## Test plan

- [x] `npm run build` — was failing with `Error: Turbopack build failed... Expression expected` at this exact line, now succeeds, all 15 routes prerender
- [x] `npx biome check components/sidebar/index.tsx` — clean

Given master is currently broken (blocking releases), flagging for priority review.