### PR TITLE
fix(ci): stop publishing a latest tag, pin compose to the current version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,9 +33,12 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: carbonbitshq/farmdb
+          # Only the version tag — it's always a new tag per release, so it never
+          # hits Docker Hub's immutable-tags rejection. Don't add a `latest` (or any
+          # other rolling) tag here; that requires overwriting an existing tag on
+          # every release, which immutability rejects outright.
           tags: |
             type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value=latest
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   farmdb:
-    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-latest}
+    # No `latest` tag is published (Docker Hub immutable tags reject repushes to it) —
+    # pin to the current release and bump FARMDB_IMAGE_TAG default on each release.
+    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-0.6.2}
     # Uncomment to build from source instead of the published image:
     # build: .
     ports:


### PR DESCRIPTION
## What

Every push to `master` has been failing Semantic Release's Docker publish job (https://github.com/carbonbits/farmdb/actions/runs/29849862825/job/88699901930):

> denied: requested access to the resource is denied - tag latest is already assigned to an image in this repository and cannot be updated due to immutability settings

Docker Hub's immutable tags are intentionally kept on for `carbonbitshq/farmdb` (deliberate security posture — prevents tag overwrites/supply-chain tampering). The workflow was fighting that by trying to repush `latest` on every release.

## How

- `.github/workflows/docker-publish.yml`: only publish the version tag (e.g. `0.6.3`). It's always a brand-new tag per release, so it never collides with an existing immutable tag — no repush ever attempted, nothing to fight with the registry policy.
- `docker-compose.yml`: since `latest` is no longer published/updated, `${FARMDB_IMAGE_TAG:-latest}` would silently resolve to whatever `latest` was frozen at before this stopped being maintained. Pinned the default to the current release (`0.6.2`) instead.

**Known follow-up, not fixed here**: the pinned default in `docker-compose.yml` now needs a manual bump alongside each release (or an automated one added later, e.g. via python-semantic-release's `version_variables`) — otherwise fresh `docker compose up` clones will pull a package that gets stale over time. Flagging rather than solving now since wiring that into python-semantic-release's version-bump automation reliably is a separate, non-trivial task worth its own PR.

## Test plan

- [x] Confirmed no other `:latest` references exist anywhere else in the repo (`grep -rn "farmdb:latest\|:latest"` across `.md`/`.yml`/`.yaml`)
- [x] Reviewed the `docker/metadata-action` output change is just the version tag, no `latest`