### PR TITLE
fix: bump docker-compose default image tag to match released version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   farmdb:
     # No `latest` tag is published (Docker Hub immutable tags reject repushes to it) —
     # pin to the current release and bump FARMDB_IMAGE_TAG default on each release.
-    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-0.6.2}
+    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-0.6.3}
     # Uncomment to build from source instead of the published image:
     # build: .
     ports:


### PR DESCRIPTION
## Summary
- \`master\`'s \`docker-compose.yml\` was left pinned to \`0.6.2\` after the \`0.6.3\` release commit bumped \`pyproject.toml\` but not the compose file's default \`FARMDB_IMAGE_TAG\` — so \`docker compose up\` on a fresh clone of \`master\` pulls a stale image.
- One-line fix: bump the default tag to \`0.6.3\`.

## Test plan
- [x] Diffed against \`master\` — single-line change, no other drift.
- N/A for automated tests (compose default value only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)