### PR TITLE
feat(web): add Crops & fields screen (WKLM-64)

### DIFF
--- a/src/apps/web/app/(app)/crops/page.test.tsx
+++ b/src/apps/web/app/(app)/crops/page.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CropsPage from "./page";
+
+describe("CropsPage", () => {
+	it("renders a card for each crop", () => {
+		render(<CropsPage />);
+		expect(screen.getByText("Maize")).toBeInTheDocument();
+		expect(screen.getByText("Beans")).toBeInTheDocument();
+		expect(screen.getByText("Kale")).toBeInTheDocument();
+		expect(screen.getByText("Fallow rotation")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/crops/page.tsx
+++ b/src/apps/web/app/(app)/crops/page.tsx
@@ -1,8 +1,126 @@
+import { Pill } from "@/components/ui/pill";
+import { ProgressBar } from "@/components/ui/progress-bar";
+
+const BAND_GRADIENT = {
+	gold: "bg-gradient-to-r from-[#C98A2B] to-[#7A5A34]",
+	green: "bg-gradient-to-r from-[#4A8A54] to-[#2C5A38]",
+	lime: "bg-gradient-to-r from-[#8FBF59] to-[#5F9A3A]",
+	tan: "bg-gradient-to-r from-[#C7B489] to-[#A9906A]",
+} as const;
+
+const CROPS = [
+	{
+		name: "Maize",
+		variety: "H614",
+		area: "6.0 ha",
+		band: "gold",
+		stage: "Vegetative",
+		percent: 45,
+		fields: "Fields A1, A2",
+		season: "Long rains 2026",
+		expected: "Expected harvest: Sep 2026",
+		next: "Next: top-dress with CAN",
+	},
+	{
+		name: "Beans",
+		variety: "Rosecoco",
+		area: "3.0 ha",
+		band: "green",
+		stage: "Flowering",
+		percent: 65,
+		fields: "Fields B1, C1",
+		season: "Long rains 2026",
+		expected: "Expected harvest: Aug 2026",
+		next: "Next: pest scouting",
+	},
+	{
+		name: "Kale",
+		variety: "Collards",
+		area: "0.8 ha",
+		band: "lime",
+		stage: "Mature",
+		percent: 90,
+		fields: "Field C2",
+		season: "Continuous",
+		expected: "Expected harvest: ongoing",
+		next: "Next: weekly harvest",
+	},
+	{
+		name: "Fallow rotation",
+		variety: "Rested",
+		area: "2.6 ha",
+		band: "tan",
+		stage: "Resting",
+		percent: 20,
+		fields: "Field D1",
+		season: "Long rains 2026",
+		expected: "Expected planting: Oct 2026",
+		next: "Next: soil test",
+	},
+] as const;
+
 export default function CropsPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Crops & fields</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+				<span className="text-[13px] text-[#75583F]">
+					4 crops across 12.4 ha · Long rains 2026 season
+				</span>
+				<button
+					type="button"
+					className="flex items-center gap-2 rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+				>
+					New planting
+				</button>
+			</div>
+
+			<div className="grid grid-cols-2 gap-4">
+				{CROPS.map((crop) => (
+					<div
+						key={crop.name}
+						className="overflow-hidden rounded-2xl border border-[#EADFCB] bg-white"
+					>
+						<div className={`h-1.5 ${BAND_GRADIENT[crop.band]}`} />
+						<div className="p-5">
+							<div className="flex items-center justify-between gap-3">
+								<div>
+									<div className="text-lg font-semibold text-[#20160F]">
+										{crop.name}
+									</div>
+									<div className="text-[12.5px] text-[#75583F]">
+										{crop.variety} · {crop.area}
+									</div>
+								</div>
+								<Pill tone="ok">{crop.stage}</Pill>
+							</div>
+
+							<ProgressBar percent={crop.percent} />
+
+							<div className="flex items-center justify-between">
+								<span className="text-xs text-[#75583F]">{crop.fields}</span>
+								<span className="text-xs font-semibold text-[#20160F]">
+									{crop.season}
+								</span>
+							</div>
+
+							<div className="mt-3.5 flex items-center justify-between border-t border-[#EADFCB] pt-3.5">
+								<div className="min-w-0">
+									<div className="text-sm font-bold text-[#20160F]">
+										{crop.expected}
+									</div>
+									<div className="text-xs text-[#75583F]">{crop.next}</div>
+								</div>
+								<button
+									type="button"
+									className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+								>
+									Map
+								</button>
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/components/ui/progress-bar.test.tsx
+++ b/src/apps/web/components/ui/progress-bar.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProgressBar } from "./progress-bar";
+
+describe("ProgressBar", () => {
+	it("renders the fill at the given percent", () => {
+		const { container } = render(<ProgressBar percent={42} />);
+		const fill = container.querySelector("div > div > div");
+		expect(fill).toHaveStyle({ width: "42%" });
+	});
+
+	it("clamps out-of-range percentages", () => {
+		const { container } = render(<ProgressBar percent={150} />);
+		const fill = container.querySelector("div > div > div");
+		expect(fill).toHaveStyle({ width: "100%" });
+	});
+});

--- a/src/apps/web/components/ui/progress-bar.tsx
+++ b/src/apps/web/components/ui/progress-bar.tsx
@@ -1,0 +1,14 @@
+interface ProgressBarProps {
+	percent: number;
+}
+
+export function ProgressBar({ percent }: ProgressBarProps) {
+	return (
+		<div className="my-3 h-[7px] overflow-hidden rounded-md bg-[#F4EAD4]">
+			<div
+				className="h-full rounded-md bg-[#346B41]"
+				style={{ width: `${Math.max(0, Math.min(100, percent))}%` }}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Stacked on #73 (Dashboard) since it reuses the `Pill` primitive from there.

- Adds a shared `ProgressBar` primitive under `components/ui/`.
- Adds the crop register: grid of crop cards (variety, area, growth-stage pill, progress bar, fields, season, expected harvest + next action, Map button back to Fields & mapping).
- UI-only with mock data, matching the design mockup — no backend crop-register endpoint wiring in this ticket's scope.

## Test plan
- [x] `npx vitest run` — all passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)