### PR TITLE
feat(web): add Finances & Reports screens (WKLM-68)

### DIFF
--- a/src/apps/web/app/(app)/finances/page.test.tsx
+++ b/src/apps/web/app/(app)/finances/page.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import FinancesPage from "./page";
+
+describe("FinancesPage", () => {
+	it("renders KPI cards and recent transactions", () => {
+		render(<FinancesPage />);
+		expect(screen.getByText("Income · July")).toBeInTheDocument();
+		expect(
+			screen.getByText("Milk delivery — Nakuru Dairy Co-op"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Milk cooperative")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/finances/page.tsx
+++ b/src/apps/web/app/(app)/finances/page.tsx
@@ -1,8 +1,202 @@
+import { Card, CardHead } from "@/components/ui/card";
+
+const KPIS = [
+	{
+		label: "Income · July",
+		value: "107,000",
+		valueCls: "text-[#346B41]",
+		sub: "KES · 4 revenue streams",
+		subCls: "text-[#957A5C]",
+	},
+	{
+		label: "Expenses · July",
+		value: "32,100",
+		valueCls: "text-[#B46038]",
+		sub: "KES · feed, inputs, labour",
+		subCls: "text-[#957A5C]",
+	},
+	{
+		label: "Net · July",
+		value: "+ 74,900",
+		valueCls: "text-[#20160F]",
+		sub: "KES · margin 70%",
+		subCls: "text-[#346B41]",
+	},
+	{
+		label: "Coop balance",
+		value: "41,200",
+		valueCls: "text-[#20160F]",
+		sub: "KES · payout on 15 Jul",
+		subCls: "text-[#957A5C]",
+	},
+] as const;
+
+const TRANSACTIONS = [
+	{
+		date: "8 Jul",
+		desc: "Milk delivery — Nakuru Dairy Co-op",
+		cat: "Income · Livestock",
+		amt: "+ KES 3,216",
+		dir: "in",
+	},
+	{
+		date: "6 Jul",
+		desc: "DAP fertilizer restock",
+		cat: "Expense · Inputs",
+		amt: "− KES 9,100",
+		dir: "out",
+	},
+	{
+		date: "4 Jul",
+		desc: "Casual labour — top-dressing",
+		cat: "Expense · Labour",
+		amt: "− KES 4,500",
+		dir: "out",
+	},
+	{
+		date: "2 Jul",
+		desc: "Kale sales — market day",
+		cat: "Income · Crops",
+		amt: "+ KES 8,400",
+		dir: "in",
+	},
+	{
+		date: "29 Jun",
+		desc: "Layer feed restock",
+		cat: "Expense · Feed",
+		amt: "− KES 6,200",
+		dir: "out",
+	},
+	{
+		date: "27 Jun",
+		desc: "Egg sales",
+		cat: "Income · Livestock",
+		amt: "+ KES 5,150",
+		dir: "in",
+	},
+	{
+		date: "24 Jun",
+		desc: "Vet callout — Baraka",
+		cat: "Expense · Livestock",
+		amt: "− KES 3,500",
+		dir: "out",
+	},
+] as const;
+
+const COST_BREAKDOWN = [
+	{ label: "Feed", amount: "KES 10,500", percent: 33, color: "#7A5A34" },
+	{ label: "Labour", amount: "KES 9,000", percent: 28, color: "#B46038" },
+	{ label: "Inputs", amount: "KES 9,100", percent: 28, color: "#346B41" },
+	{ label: "Livestock", amount: "KES 3,500", percent: 11, color: "#4A6D7A" },
+] as const;
+
 export default function FinancesPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Finances</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="grid grid-cols-4 gap-4">
+				{KPIS.map((kpi) => (
+					<Card key={kpi.label}>
+						<div className="text-[12.5px] font-medium text-[#75583F]">
+							{kpi.label}
+						</div>
+						<div
+							className={`font-serif text-[27px] font-semibold leading-none ${kpi.valueCls}`}
+						>
+							{kpi.value}
+						</div>
+						<div className={`mt-0.5 text-xs ${kpi.subCls}`}>{kpi.sub}</div>
+					</Card>
+				))}
+			</div>
+
+			<div className="mt-[18px] grid grid-cols-[1.6fr_1fr] gap-[18px]">
+				<Card>
+					<CardHead
+						title="Recent transactions"
+						action={
+							<button
+								type="button"
+								className="text-[12.5px] font-semibold text-[#346B41]"
+							>
+								Add entry →
+							</button>
+						}
+					/>
+					{TRANSACTIONS.map((txn) => (
+						<div
+							key={`${txn.date}-${txn.desc}`}
+							className="flex items-center gap-3.5 border-t border-[#EADFCB] py-3 first:border-t-0"
+						>
+							<span className="w-[52px] shrink-0 font-mono text-[11.5px] text-[#957A5C]">
+								{txn.date}
+							</span>
+							<div className="min-w-0 flex-1">
+								<div className="text-[13.5px] font-semibold text-[#20160F]">
+									{txn.desc}
+								</div>
+								<div className="text-xs text-[#957A5C]">{txn.cat}</div>
+							</div>
+							<span
+								className={`ml-auto whitespace-nowrap text-[13.5px] font-bold ${
+									txn.dir === "in" ? "text-[#346B41]" : "text-[#B46038]"
+								}`}
+							>
+								{txn.amt}
+							</span>
+						</div>
+					))}
+				</Card>
+
+				<div className="flex flex-col gap-4">
+					<Card>
+						<div className="mb-3 text-base font-semibold text-[#20160F]">
+							Where costs go · July
+						</div>
+						<div className="my-2 flex h-2.5 overflow-hidden rounded-md">
+							{COST_BREAKDOWN.map((c) => (
+								<div
+									key={c.label}
+									style={{ width: `${c.percent}%`, background: c.color }}
+								/>
+							))}
+						</div>
+						<div className="mt-3 flex flex-col gap-2">
+							{COST_BREAKDOWN.map((c) => (
+								<div
+									key={c.label}
+									className="flex items-center justify-between"
+								>
+									<span className="flex items-center gap-2 text-sm text-[#20160F]">
+										<span
+											className="h-2 w-2 rounded-full"
+											style={{ background: c.color }}
+										/>
+										{c.label}
+									</span>
+									<span className="text-sm font-semibold text-[#20160F]">
+										{c.amount}
+									</span>
+								</div>
+							))}
+						</div>
+					</Card>
+
+					<Card warm>
+						<div className="mb-1.5 text-base font-semibold text-[#20160F]">
+							Milk cooperative
+						</div>
+						<div className="text-[13px] text-[#75583F]">
+							1,340 L delivered this month at KES 67/L. Next payout 15 July.
+						</div>
+						<button
+							type="button"
+							className="mt-3 rounded-[10px] bg-[#346B41] px-3 py-[7px] text-[12.5px] font-semibold text-[#F4EAD4]"
+						>
+							View production
+						</button>
+					</Card>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/reports/page.test.tsx
+++ b/src/apps/web/app/(app)/reports/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ReportsPage from "./page";
+
+describe("ReportsPage", () => {
+	it("renders all six report cards", () => {
+		render(<ReportsPage />);
+		expect(screen.getByText("Season summary")).toBeInTheDocument();
+		expect(screen.getByText("Milk yield trend")).toBeInTheDocument();
+		expect(screen.getByText("Cost per crop")).toBeInTheDocument();
+		expect(screen.getByText("Export data")).toBeInTheDocument();
+		expect(screen.getByText("Profit & loss")).toBeInTheDocument();
+		expect(screen.getByText("Records health")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/reports/page.tsx
+++ b/src/apps/web/app/(app)/reports/page.tsx
@@ -1,8 +1,163 @@
+import { Pill } from "@/components/ui/pill";
+import { ProgressBar } from "@/components/ui/progress-bar";
+
+const MILK_TREND_BARS = [70, 76, 80, 88, 92, 96] as const;
+
+const COST_PER_CROP = [
+	{ crop: "Maize", cost: "KES 23,200" },
+	{ crop: "Beans", cost: "KES 11,600" },
+	{ crop: "Kale", cost: "KES 4,300" },
+] as const;
+
 export default function ReportsPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Reports</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-4 text-[13px] text-[#75583F]">
+				Season and financial summaries · Long rains 2026
+			</div>
+
+			<div className="grid grid-cols-3 items-start gap-4">
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="flex items-center justify-between">
+						<div className="text-base font-semibold text-[#20160F]">
+							Season summary
+						</div>
+						<Pill tone="ok">On track</Pill>
+					</div>
+					<div className="flex flex-wrap gap-[26px]">
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#20160F]">
+								12.4 ha
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Under crop</div>
+						</div>
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#20160F]">
+								~21.4 t
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">
+								Projected yield
+							</div>
+						</div>
+					</div>
+					<button
+						type="button"
+						className="self-start rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						Open report
+					</button>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Milk yield trend
+					</div>
+					<div className="flex h-[70px] items-end gap-2">
+						{MILK_TREND_BARS.map((h) => (
+							<div
+								key={h}
+								className="min-h-1.5 flex-1 rounded-t-md bg-[#CDB98F]"
+								style={{ height: `${h}%` }}
+							/>
+						))}
+					</div>
+					<div className="text-xs text-[#957A5C]">
+						Feb → Jul · +14% since dry season feed change
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Cost per crop
+					</div>
+					<div className="flex flex-col gap-2">
+						{COST_PER_CROP.map((row) => (
+							<div key={row.crop} className="flex items-center justify-between">
+								<span className="text-sm text-[#20160F]">{row.crop}</span>
+								<span className="text-sm font-semibold text-[#20160F]">
+									{row.cost}
+								</span>
+							</div>
+						))}
+					</div>
+					<button
+						type="button"
+						className="self-start rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						Open report
+					</button>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Export data
+					</div>
+					<div className="text-[13px] text-[#75583F]">
+						Download records for records-keeping, loans or cooperative
+						reporting.
+					</div>
+					<div className="flex gap-2">
+						<button
+							type="button"
+							className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+						>
+							CSV
+						</button>
+						<button
+							type="button"
+							className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+						>
+							PDF
+						</button>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="flex items-center justify-between">
+						<div className="text-base font-semibold text-[#20160F]">
+							Profit & loss
+						</div>
+						<Pill tone="ok">+70% margin</Pill>
+					</div>
+					<div className="flex flex-wrap gap-[26px]">
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#346B41]">
+								107k
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Income</div>
+						</div>
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#B46038]">
+								32k
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Costs</div>
+						</div>
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#20160F]">
+								75k
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Net</div>
+						</div>
+					</div>
+					<button
+						type="button"
+						className="self-start rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						Open report
+					</button>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-[#FCF8F0] p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Records health
+					</div>
+					<div className="text-[13px] text-[#75583F]">
+						94% of activities logged this season. Keep it up for accurate
+						reports.
+					</div>
+					<ProgressBar percent={94} />
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/components/ui/progress-bar.test.tsx
+++ b/src/apps/web/components/ui/progress-bar.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProgressBar } from "./progress-bar";
+
+describe("ProgressBar", () => {
+	it("renders the fill at the given percent", () => {
+		const { container } = render(<ProgressBar percent={42} />);
+		const fill = container.querySelector("div > div > div");
+		expect(fill).toHaveStyle({ width: "42%" });
+	});
+
+	it("clamps out-of-range percentages", () => {
+		const { container } = render(<ProgressBar percent={150} />);
+		const fill = container.querySelector("div > div > div");
+		expect(fill).toHaveStyle({ width: "100%" });
+	});
+});

--- a/src/apps/web/components/ui/progress-bar.tsx
+++ b/src/apps/web/components/ui/progress-bar.tsx
@@ -1,0 +1,14 @@
+interface ProgressBarProps {
+	percent: number;
+}
+
+export function ProgressBar({ percent }: ProgressBarProps) {
+	return (
+		<div className="my-3 h-[7px] overflow-hidden rounded-md bg-[#F4EAD4]">
+			<div
+				className="h-full rounded-md bg-[#346B41]"
+				style={{ width: `${Math.max(0, Math.min(100, percent))}%` }}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Stacked on #73 (Dashboard) since it reuses `Card`/`CardHead`/`Pill` from there. Also includes `ProgressBar` (identical copy of the one added on the sibling WKLM-64 branch/#75 — Reports needs it and this branch doesn't include that PR's commit; will de-dupe naturally once both merge).

**Finances**: 4 KPI cards (income/expenses/net/coop balance), recent transactions list, cost-breakdown stacked bar + legend, coop payout summary card.

**Reports**: grid of 6 report cards — season summary, milk yield trend (sparkline bars), cost per crop, export data (CSV/PDF), profit & loss, records health (progress bar).

UI-only with mock data, matching the design mockup.

## Test plan
- [x] `npx vitest run` — all passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)