### PR TITLE
feat(web): add Connect pricing screen (WKLM-70)

### DIFF
--- a/src/apps/web/app/(app)/admin/pricing/page.test.tsx
+++ b/src/apps/web/app/(app)/admin/pricing/page.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ConnectPricingPage from "./page";
+
+describe("ConnectPricingPage", () => {
+	it("shows Maize's detail by default", () => {
+		render(<ConnectPricingPage />);
+		expect(screen.getByText("Sliding-scale controls")).toBeInTheDocument();
+		expect(
+			screen.getByText(/Price climbs into the pre-harvest window/),
+		).toBeInTheDocument();
+	});
+
+	it("switches the detail panel when a different dataset is selected", () => {
+		render(<ConnectPricingPage />);
+		fireEvent.click(screen.getByRole("button", { name: /Kale/ }));
+		expect(
+			screen.getByText(/Continuous harvest is pushing supply up/),
+		).toBeInTheDocument();
+	});
+
+	it("shows the empty schedule state for a dataset with no scheduled changes", () => {
+		render(<ConnectPricingPage />);
+		fireEvent.click(screen.getByRole("button", { name: /Beans/ }));
+		expect(
+			screen.getByText("No upcoming changes — this rule holds until edited."),
+		).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/admin/pricing/page.tsx
+++ b/src/apps/web/app/(app)/admin/pricing/page.tsx
@@ -1,8 +1,438 @@
+"use client";
+
+import { Bell, FileClock, Send } from "lucide-react";
+import { useState } from "react";
+import { Pill } from "@/components/ui/pill";
+import { PriceChart } from "@/components/ui/price-chart";
+
+const MONTH_LABELS = ["Feb", "Mar", "Apr", "May", "Jun", "Jul"];
+
+type Trend = "up" | "down" | "steady";
+
+const TREND_CLS = {
+	up: "text-[#B4552A]",
+	down: "text-[#2C7A4A]",
+	steady: "text-[#957A5C]",
+} as const;
+
+interface Scope {
+	id: string;
+	name: string;
+	cat: string;
+	price: string;
+	trend: Trend;
+	trendLabel: string;
+	sparkline: number[];
+	driver: string;
+	points: number[];
+	floor: number;
+	ceiling: number;
+	todayIndex: number;
+	peakIndex: number;
+	harvestIndex?: number;
+	sensitivity: string;
+	base: string;
+	multiplier: string;
+	stakeholders: number;
+	schedule: {
+		date: string;
+		change: string;
+		note: string;
+		status: "pending" | "confirmed";
+	}[];
+}
+
+const SCOPES: Scope[] = [
+	{
+		id: "maize",
+		name: "Maize",
+		cat: "Grain · per connect",
+		price: "KES 58",
+		trend: "up",
+		trendLabel: "+9% this week",
+		sparkline: [40, 42, 45, 50, 58, 54],
+		driver:
+			"Price climbs into the pre-harvest window, then eases once new stock lands.",
+		points: [40, 42, 45, 50, 58, 46],
+		floor: 32,
+		ceiling: 62,
+		todayIndex: 5,
+		peakIndex: 4,
+		harvestIndex: 4,
+		sensitivity: "High",
+		base: "KES 38",
+		multiplier: "1.5×",
+		stakeholders: 14,
+		schedule: [
+			{
+				date: "20 Jul",
+				change: "Ceiling → KES 65",
+				note: "Post-harvest cooldown",
+				status: "pending",
+			},
+			{
+				date: "1 Sep",
+				change: "Base → KES 40",
+				note: "New season baseline",
+				status: "confirmed",
+			},
+		],
+	},
+	{
+		id: "beans",
+		name: "Beans",
+		cat: "Grain · per connect",
+		price: "KES 44",
+		trend: "steady",
+		trendLabel: "Flat this week",
+		sparkline: [41, 42, 43, 44, 44, 44],
+		driver:
+			"Stable demand from cooperative buyers keeps this dataset near its base price.",
+		points: [41, 42, 43, 44, 44, 44],
+		floor: 30,
+		ceiling: 50,
+		todayIndex: 5,
+		peakIndex: 3,
+		sensitivity: "Low",
+		base: "KES 40",
+		multiplier: "1.1×",
+		stakeholders: 9,
+		schedule: [],
+	},
+	{
+		id: "kale",
+		name: "Kale",
+		cat: "Vegetable · per connect",
+		price: "KES 21",
+		trend: "down",
+		trendLabel: "−6% this week",
+		sparkline: [26, 25, 24, 22, 21, 20],
+		driver:
+			"Continuous harvest is pushing supply up, easing price toward the floor.",
+		points: [26, 25, 24, 22, 21, 20],
+		floor: 18,
+		ceiling: 32,
+		todayIndex: 5,
+		peakIndex: 0,
+		sensitivity: "Medium",
+		base: "KES 20",
+		multiplier: "1.3×",
+		stakeholders: 6,
+		schedule: [
+			{
+				date: "15 Jul",
+				change: "Floor → KES 16",
+				note: "Match wholesale trend",
+				status: "pending",
+			},
+		],
+	},
+];
+
+const STATS = [
+	{ v: "3", l: "Priced datasets" },
+	{ v: "29", l: "Stakeholders on notice" },
+	{ v: "KES 41", l: "Avg price / connect" },
+	{ v: "2", l: "Changes scheduled" },
+];
+
 export default function ConnectPricingPage() {
+	const [selectedId, setSelectedId] = useState("maize");
+	const scope = SCOPES.find((s) => s.id === selectedId) ?? SCOPES[0];
+
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Connect pricing</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-[18px] flex flex-wrap items-center justify-between gap-3">
+				<p className="max-w-[560px] text-[13px] text-[#75583F]">
+					A semi-open marketplace: connect prices slide with season and demand.
+					Adjust a rule and stakeholders are notified before it takes effect.
+				</p>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						<FileClock size={16} aria-hidden="true" />
+						Change log
+					</button>
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] bg-[#346B41] px-4 py-2.5 text-[13.5px] font-semibold text-[#F4EAD4]"
+					>
+						Announce update
+					</button>
+				</div>
+			</div>
+
+			<div className="mb-5 grid grid-cols-4 gap-4">
+				{STATS.map((stat) => (
+					<div
+						key={stat.l}
+						className="rounded-2xl border border-[#EADFCB] bg-white px-[18px] py-4"
+					>
+						<div className="font-serif text-2xl font-semibold leading-tight text-[#20160F]">
+							{stat.v}
+						</div>
+						<div className="mt-1 text-xs text-[#957A5C]">{stat.l}</div>
+					</div>
+				))}
+			</div>
+
+			<div className="grid grid-cols-[336px_1fr] items-start gap-[18px]">
+				<div>
+					<div className="mb-2 text-[11px] font-bold uppercase tracking-[1.2px] text-[#957A5C]">
+						Priced datasets
+					</div>
+					<div className="flex flex-col gap-2">
+						{SCOPES.map((s) => (
+							<button
+								key={s.id}
+								type="button"
+								onClick={() => setSelectedId(s.id)}
+								className={`flex w-full items-center gap-3 rounded-[13px] border bg-white px-3.5 py-2.5 text-left ${
+									s.id === selectedId ? "border-[#B49A78]" : "border-[#EADFCB]"
+								}`}
+							>
+								<svg
+									viewBox="0 0 92 30"
+									className="h-[30px] w-[92px] shrink-0"
+									aria-hidden="true"
+								>
+									<path
+										d={s.sparkline
+											.map(
+												(v, i) =>
+													`${i === 0 ? "M" : "L"} ${(i / (s.sparkline.length - 1)) * 92} ${
+														30 -
+														((v - Math.min(...s.sparkline)) /
+															(Math.max(...s.sparkline) -
+																Math.min(...s.sparkline) || 1)) *
+															26 -
+														2
+													}`,
+											)
+											.join(" ")}
+										fill="none"
+										stroke={s.trend === "down" ? "#2C7A4A" : "#B4552A"}
+										strokeWidth={2}
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									/>
+								</svg>
+								<div className="min-w-0 flex-1">
+									<div className="text-[13.5px] font-semibold leading-tight text-[#20160F]">
+										{s.name}
+									</div>
+									<div className="mt-0.5 text-[11px] text-[#957A5C]">
+										{s.cat}
+									</div>
+								</div>
+								<div className="text-right">
+									<div className="text-[13.5px] font-bold text-[#20160F]">
+										{s.price}
+									</div>
+									<div
+										className={`text-[11px] font-bold ${TREND_CLS[s.trend]}`}
+									>
+										{s.trendLabel}
+									</div>
+								</div>
+							</button>
+						))}
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-4">
+					<div className="rounded-2xl border border-[#EADFCB] bg-white px-5 py-[18px]">
+						<div className="flex flex-wrap items-center justify-between gap-3">
+							<div>
+								<div className="font-serif text-[19px] font-semibold text-[#20160F]">
+									{scope.name}
+								</div>
+								<span className={`text-xs font-bold ${TREND_CLS[scope.trend]}`}>
+									{scope.trendLabel}
+								</span>
+							</div>
+							<div className="text-right">
+								<div className="font-serif text-[30px] font-semibold leading-none text-[#20160F]">
+									{scope.price}
+								</div>
+								<div className="text-[11.5px] text-[#957A5C]">
+									current · per connect / month
+								</div>
+							</div>
+						</div>
+						<p className="mb-1.5 mt-1.5 text-[12.5px] text-[#957A5C]">
+							{scope.driver}
+						</p>
+						<PriceChart
+							points={scope.points}
+							labels={MONTH_LABELS}
+							floor={scope.floor}
+							ceiling={scope.ceiling}
+							todayIndex={scope.todayIndex}
+							peakIndex={scope.peakIndex}
+							harvestIndex={scope.harvestIndex}
+						/>
+					</div>
+
+					<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+						<div className="mb-3.5 flex items-center justify-between">
+							<div className="text-base font-semibold text-[#20160F]">
+								Sliding-scale controls
+							</div>
+							<Pill tone="neutral">{scope.sensitivity} sensitivity</Pill>
+						</div>
+						<div className="grid grid-cols-2 gap-x-5 gap-y-3.5">
+							<div>
+								<label
+									htmlFor="base-price"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Base price (off-season)
+								</label>
+								<input
+									id="base-price"
+									defaultValue={scope.base}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="multiplier"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Seasonal multiplier at peak
+								</label>
+								<input
+									id="multiplier"
+									defaultValue={scope.multiplier}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="floor-price"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Floor (never below)
+								</label>
+								<input
+									id="floor-price"
+									defaultValue={`KES ${scope.floor}`}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="ceiling-price"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Ceiling (never above)
+								</label>
+								<input
+									id="ceiling-price"
+									defaultValue={`KES ${scope.ceiling}`}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+						</div>
+						<div className="mt-4">
+							<label
+								htmlFor="sensitivity-range"
+								className="mb-2.5 block text-xs font-semibold text-[#3F2D22]"
+							>
+								Demand sensitivity — how sharply price reacts near harvest
+							</label>
+							<input
+								id="sensitivity-range"
+								type="range"
+								min={0}
+								max={100}
+								defaultValue={72}
+								className="w-full accent-[#346B41]"
+							/>
+						</div>
+						<div className="mt-[18px] flex flex-wrap items-center justify-between gap-3">
+							<span className="text-xs text-[#957A5C]">
+								Changes take effect after the notice period.
+							</span>
+							<div className="flex gap-2">
+								<button
+									type="button"
+									className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+								>
+									Save draft
+								</button>
+								<button
+									type="button"
+									className="rounded-[10px] bg-[#346B41] px-3.5 py-2 text-[13px] font-semibold text-[#F4EAD4]"
+								>
+									Schedule change
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+						<div className="mb-3.5 flex items-center justify-between">
+							<div className="text-base font-semibold text-[#20160F]">
+								Scheduled changes
+							</div>
+							<span className="font-mono text-[11px] text-[#957A5C]">
+								Notice: 14 days
+							</span>
+						</div>
+						{scope.schedule.length > 0 ? (
+							scope.schedule.map((s) => (
+								<div
+									key={s.date}
+									className="flex items-center gap-3.5 border-t border-[#EADFCB] py-3.5 first:border-t-0"
+								>
+									<div className="w-24 shrink-0 font-mono text-xs font-semibold text-[#3F2D22]">
+										{s.date}
+									</div>
+									<div className="min-w-0 flex-1">
+										<div className="text-[13.5px] font-semibold text-[#20160F]">
+											{s.change}
+										</div>
+										<div className="text-xs text-[#957A5C]">{s.note}</div>
+									</div>
+									<Pill tone={s.status === "confirmed" ? "ok" : "watch"}>
+										{s.status}
+									</Pill>
+								</div>
+							))
+						) : (
+							<p className="py-2 text-[13px] text-[#957A5C]">
+								No upcoming changes — this rule holds until edited.
+							</p>
+						)}
+
+						<div className="mt-3.5 flex items-center gap-3.5 rounded-[13px] border border-[#E6CFA2] bg-gradient-to-r from-[#F6EAD2] to-[#F2DFBF] px-4 py-3.5 text-[#7A5320]">
+							<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#E8C98A] text-[#6D4614]">
+								<Bell size={18} aria-hidden="true" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<div className="text-[13px] font-bold">
+									{scope.stakeholders} stakeholders on notice
+								</div>
+								<div className="text-xs text-[#8A6224]">
+									Farms, buyers and agents holding this connect are notified 14
+									days before any price change.
+								</div>
+							</div>
+							<button
+								type="button"
+								className="ml-auto flex shrink-0 items-center gap-2 rounded-[10px] border border-[#E0C288] bg-white px-3.5 py-2 text-[12.5px] font-semibold text-[#7A5320]"
+							>
+								<Send size={16} aria-hidden="true" />
+								Notify now
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/components/ui/price-chart.test.tsx
+++ b/src/apps/web/components/ui/price-chart.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PriceChart } from "./price-chart";
+
+describe("PriceChart", () => {
+	it("renders an accessible image with floor and ceiling labels", () => {
+		render(
+			<PriceChart
+				points={[40, 42, 45, 50, 58, 46, 41]}
+				labels={["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul"]}
+				floor={35}
+				ceiling={60}
+				todayIndex={6}
+				peakIndex={4}
+				harvestIndex={4}
+			/>,
+		);
+		expect(screen.getByRole("img")).toBeInTheDocument();
+		expect(screen.getByText("Floor KES 35")).toBeInTheDocument();
+		expect(screen.getByText("Ceiling KES 60")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/components/ui/price-chart.tsx
+++ b/src/apps/web/components/ui/price-chart.tsx
@@ -1,0 +1,203 @@
+interface PriceChartProps {
+	points: number[];
+	labels: string[];
+	floor: number;
+	ceiling: number;
+	todayIndex: number;
+	peakIndex: number;
+	harvestIndex?: number;
+}
+
+const WIDTH = 700;
+const HEIGHT = 250;
+const X0 = 10;
+const X1 = 650;
+const Y_TOP = 20;
+const Y_BOT = 200;
+
+export function PriceChart({
+	points,
+	labels,
+	floor,
+	ceiling,
+	todayIndex,
+	peakIndex,
+	harvestIndex,
+}: PriceChartProps) {
+	const domainMin = Math.min(floor, ...points) * 0.92;
+	const domainMax = Math.max(ceiling, ...points) * 1.05;
+
+	const x = (i: number) => X0 + (i / (points.length - 1)) * (X1 - X0);
+	const y = (v: number) =>
+		Y_BOT - ((v - domainMin) / (domainMax - domainMin)) * (Y_BOT - Y_TOP);
+
+	const linePath = points
+		.map((v, i) => `${i === 0 ? "M" : "L"} ${x(i)} ${y(v)}`)
+		.join(" ");
+	const areaPath = `${linePath} L ${x(points.length - 1)} ${Y_BOT} L ${x(0)} ${Y_BOT} Z`;
+
+	return (
+		<svg
+			viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+			className="mt-1 block w-full"
+			role="img"
+			aria-label="Price over the season, with floor and ceiling bounds"
+		>
+			<line
+				x1={X0}
+				x2={X1}
+				y1={Y_TOP}
+				y2={Y_TOP}
+				stroke="#EFE7D6"
+				strokeWidth={1}
+			/>
+			<line
+				x1={X0}
+				x2={X1}
+				y1={Y_BOT}
+				y2={Y_BOT}
+				stroke="#E3D8C2"
+				strokeWidth={1}
+			/>
+
+			<path d={areaPath} fill="rgba(74,138,84,0.12)" stroke="none" />
+			<path
+				d={linePath}
+				fill="none"
+				stroke="#4A8A54"
+				strokeWidth={2.5}
+				strokeLinejoin="round"
+				strokeLinecap="round"
+			/>
+
+			<line
+				x1={X0}
+				x2={X1}
+				y1={y(ceiling)}
+				y2={y(ceiling)}
+				stroke="#B4552A"
+				strokeWidth={1}
+				strokeDasharray="4 4"
+				opacity={0.7}
+			/>
+			<text
+				x={X1}
+				y={y(ceiling)}
+				dx={-2}
+				dy={-5}
+				textAnchor="end"
+				fontSize={10}
+				fontWeight={700}
+				fill="#B4552A"
+			>
+				Ceiling KES {ceiling}
+			</text>
+
+			<line
+				x1={X0}
+				x2={X1}
+				y1={y(floor)}
+				y2={y(floor)}
+				stroke="#7A634A"
+				strokeWidth={1}
+				strokeDasharray="4 4"
+				opacity={0.55}
+			/>
+			<text
+				x={X0}
+				y={y(floor)}
+				dx={2}
+				dy={12}
+				fontSize={10}
+				fontWeight={700}
+				fill="#7A634A"
+			>
+				Floor KES {floor}
+			</text>
+
+			{harvestIndex !== undefined && (
+				<>
+					<line
+						x1={x(harvestIndex)}
+						x2={x(harvestIndex)}
+						y1={Y_TOP}
+						y2={Y_BOT}
+						stroke="#C98A2B"
+						strokeWidth={1.5}
+						strokeDasharray="3 3"
+					/>
+					<text
+						x={x(harvestIndex)}
+						y={Y_TOP}
+						dy={-4}
+						textAnchor="middle"
+						fontSize={10}
+						fontWeight={700}
+						fill="#A06A1E"
+					>
+						Harvest
+					</text>
+				</>
+			)}
+
+			<line
+				x1={x(todayIndex)}
+				x2={x(todayIndex)}
+				y1={Y_TOP}
+				y2={Y_BOT}
+				stroke="#2C5A38"
+				strokeWidth={1.5}
+			/>
+			<circle
+				cx={x(peakIndex)}
+				cy={y(points[peakIndex])}
+				r={4}
+				fill="#B4552A"
+			/>
+			<text
+				x={x(peakIndex)}
+				y={y(points[peakIndex])}
+				dx={9}
+				dy={-6}
+				fontSize={10.5}
+				fontWeight={700}
+				fill="#B4552A"
+			>
+				KES {points[peakIndex]}
+			</text>
+			<circle
+				cx={x(todayIndex)}
+				cy={y(points[todayIndex])}
+				r={5}
+				fill="#fff"
+				stroke="#2C5A38"
+				strokeWidth={2.5}
+			/>
+			<text
+				x={x(todayIndex)}
+				y={Y_BOT}
+				dy={30}
+				textAnchor="middle"
+				fontSize={10.5}
+				fontWeight={700}
+				fill="#2C5A38"
+			>
+				Today
+			</text>
+
+			{labels.map((label, i) => (
+				<text
+					key={label}
+					x={x(i)}
+					y={Y_BOT}
+					dy={16}
+					textAnchor="middle"
+					fontSize={10.5}
+					fill="#9A8570"
+				>
+					{label}
+				</text>
+			))}
+		</svg>
+	);
+}


### PR DESCRIPTION
## Summary
Stacked on #73 (Dashboard) since it reuses the `Pill` primitive from there.

- Adds a shared `PriceChart` primitive: SVG line/area chart with floor/ceiling dashed bounds, harvest marker, today marker, peak-price annotation, and month tick labels.
- Priced-datasets list (with sparklines) + selected-dataset detail: price chart, driver text, sliding-scale controls (base/multiplier/floor/ceiling inputs + demand-sensitivity range slider), scheduled-changes list, stakeholder-notify bar.
- Per WKLM-70's own epic description, the tier for this feature is **explicitly unresolved** — this PR is UI only (no real pricing/gating logic), platform-admin-gated at the nav level like every other WKLM screen so far. Matches CORE-293/294's scope.
- Manually verified in a live browser session — screenshots confirmed the chart renders correctly and matches the design mockup (including fixing a label-clipping issue on the "Today" marker at the chart's right edge).

## Test plan
- [x] `npx vitest run` — all passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean
- [x] Manual visual verification via Playwright screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)