### PR TITLE
feat(web): land Fields, Crops, Livestock, Tasks, Inventory, Finances/Reports, Connects, Pricing, Coop into master

### DIFF
--- a/src/apps/web/app/(app)/admin/pricing/page.test.tsx
+++ b/src/apps/web/app/(app)/admin/pricing/page.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ConnectPricingPage from "./page";
+
+describe("ConnectPricingPage", () => {
+	it("shows Maize's detail by default", () => {
+		render(<ConnectPricingPage />);
+		expect(screen.getByText("Sliding-scale controls")).toBeInTheDocument();
+		expect(
+			screen.getByText(/Price climbs into the pre-harvest window/),
+		).toBeInTheDocument();
+	});
+
+	it("switches the detail panel when a different dataset is selected", () => {
+		render(<ConnectPricingPage />);
+		fireEvent.click(screen.getByRole("button", { name: /Kale/ }));
+		expect(
+			screen.getByText(/Continuous harvest is pushing supply up/),
+		).toBeInTheDocument();
+	});
+
+	it("shows the empty schedule state for a dataset with no scheduled changes", () => {
+		render(<ConnectPricingPage />);
+		fireEvent.click(screen.getByRole("button", { name: /Beans/ }));
+		expect(
+			screen.getByText("No upcoming changes — this rule holds until edited."),
+		).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/admin/pricing/page.tsx
+++ b/src/apps/web/app/(app)/admin/pricing/page.tsx
@@ -1,8 +1,438 @@
+"use client";
+
+import { Bell, FileClock, Send } from "lucide-react";
+import { useState } from "react";
+import { Pill } from "@/components/ui/pill";
+import { PriceChart } from "@/components/ui/price-chart";
+
+const MONTH_LABELS = ["Feb", "Mar", "Apr", "May", "Jun", "Jul"];
+
+type Trend = "up" | "down" | "steady";
+
+const TREND_CLS = {
+	up: "text-[#B4552A]",
+	down: "text-[#2C7A4A]",
+	steady: "text-[#957A5C]",
+} as const;
+
+interface Scope {
+	id: string;
+	name: string;
+	cat: string;
+	price: string;
+	trend: Trend;
+	trendLabel: string;
+	sparkline: number[];
+	driver: string;
+	points: number[];
+	floor: number;
+	ceiling: number;
+	todayIndex: number;
+	peakIndex: number;
+	harvestIndex?: number;
+	sensitivity: string;
+	base: string;
+	multiplier: string;
+	stakeholders: number;
+	schedule: {
+		date: string;
+		change: string;
+		note: string;
+		status: "pending" | "confirmed";
+	}[];
+}
+
+const SCOPES: Scope[] = [
+	{
+		id: "maize",
+		name: "Maize",
+		cat: "Grain · per connect",
+		price: "KES 58",
+		trend: "up",
+		trendLabel: "+9% this week",
+		sparkline: [40, 42, 45, 50, 58, 54],
+		driver:
+			"Price climbs into the pre-harvest window, then eases once new stock lands.",
+		points: [40, 42, 45, 50, 58, 46],
+		floor: 32,
+		ceiling: 62,
+		todayIndex: 5,
+		peakIndex: 4,
+		harvestIndex: 4,
+		sensitivity: "High",
+		base: "KES 38",
+		multiplier: "1.5×",
+		stakeholders: 14,
+		schedule: [
+			{
+				date: "20 Jul",
+				change: "Ceiling → KES 65",
+				note: "Post-harvest cooldown",
+				status: "pending",
+			},
+			{
+				date: "1 Sep",
+				change: "Base → KES 40",
+				note: "New season baseline",
+				status: "confirmed",
+			},
+		],
+	},
+	{
+		id: "beans",
+		name: "Beans",
+		cat: "Grain · per connect",
+		price: "KES 44",
+		trend: "steady",
+		trendLabel: "Flat this week",
+		sparkline: [41, 42, 43, 44, 44, 44],
+		driver:
+			"Stable demand from cooperative buyers keeps this dataset near its base price.",
+		points: [41, 42, 43, 44, 44, 44],
+		floor: 30,
+		ceiling: 50,
+		todayIndex: 5,
+		peakIndex: 3,
+		sensitivity: "Low",
+		base: "KES 40",
+		multiplier: "1.1×",
+		stakeholders: 9,
+		schedule: [],
+	},
+	{
+		id: "kale",
+		name: "Kale",
+		cat: "Vegetable · per connect",
+		price: "KES 21",
+		trend: "down",
+		trendLabel: "−6% this week",
+		sparkline: [26, 25, 24, 22, 21, 20],
+		driver:
+			"Continuous harvest is pushing supply up, easing price toward the floor.",
+		points: [26, 25, 24, 22, 21, 20],
+		floor: 18,
+		ceiling: 32,
+		todayIndex: 5,
+		peakIndex: 0,
+		sensitivity: "Medium",
+		base: "KES 20",
+		multiplier: "1.3×",
+		stakeholders: 6,
+		schedule: [
+			{
+				date: "15 Jul",
+				change: "Floor → KES 16",
+				note: "Match wholesale trend",
+				status: "pending",
+			},
+		],
+	},
+];
+
+const STATS = [
+	{ v: "3", l: "Priced datasets" },
+	{ v: "29", l: "Stakeholders on notice" },
+	{ v: "KES 41", l: "Avg price / connect" },
+	{ v: "2", l: "Changes scheduled" },
+];
+
 export default function ConnectPricingPage() {
+	const [selectedId, setSelectedId] = useState("maize");
+	const scope = SCOPES.find((s) => s.id === selectedId) ?? SCOPES[0];
+
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Connect pricing</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-[18px] flex flex-wrap items-center justify-between gap-3">
+				<p className="max-w-[560px] text-[13px] text-[#75583F]">
+					A semi-open marketplace: connect prices slide with season and demand.
+					Adjust a rule and stakeholders are notified before it takes effect.
+				</p>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						<FileClock size={16} aria-hidden="true" />
+						Change log
+					</button>
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] bg-[#346B41] px-4 py-2.5 text-[13.5px] font-semibold text-[#F4EAD4]"
+					>
+						Announce update
+					</button>
+				</div>
+			</div>
+
+			<div className="mb-5 grid grid-cols-4 gap-4">
+				{STATS.map((stat) => (
+					<div
+						key={stat.l}
+						className="rounded-2xl border border-[#EADFCB] bg-white px-[18px] py-4"
+					>
+						<div className="font-serif text-2xl font-semibold leading-tight text-[#20160F]">
+							{stat.v}
+						</div>
+						<div className="mt-1 text-xs text-[#957A5C]">{stat.l}</div>
+					</div>
+				))}
+			</div>
+
+			<div className="grid grid-cols-[336px_1fr] items-start gap-[18px]">
+				<div>
+					<div className="mb-2 text-[11px] font-bold uppercase tracking-[1.2px] text-[#957A5C]">
+						Priced datasets
+					</div>
+					<div className="flex flex-col gap-2">
+						{SCOPES.map((s) => (
+							<button
+								key={s.id}
+								type="button"
+								onClick={() => setSelectedId(s.id)}
+								className={`flex w-full items-center gap-3 rounded-[13px] border bg-white px-3.5 py-2.5 text-left ${
+									s.id === selectedId ? "border-[#B49A78]" : "border-[#EADFCB]"
+								}`}
+							>
+								<svg
+									viewBox="0 0 92 30"
+									className="h-[30px] w-[92px] shrink-0"
+									aria-hidden="true"
+								>
+									<path
+										d={s.sparkline
+											.map(
+												(v, i) =>
+													`${i === 0 ? "M" : "L"} ${(i / (s.sparkline.length - 1)) * 92} ${
+														30 -
+														((v - Math.min(...s.sparkline)) /
+															(Math.max(...s.sparkline) -
+																Math.min(...s.sparkline) || 1)) *
+															26 -
+														2
+													}`,
+											)
+											.join(" ")}
+										fill="none"
+										stroke={s.trend === "down" ? "#2C7A4A" : "#B4552A"}
+										strokeWidth={2}
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									/>
+								</svg>
+								<div className="min-w-0 flex-1">
+									<div className="text-[13.5px] font-semibold leading-tight text-[#20160F]">
+										{s.name}
+									</div>
+									<div className="mt-0.5 text-[11px] text-[#957A5C]">
+										{s.cat}
+									</div>
+								</div>
+								<div className="text-right">
+									<div className="text-[13.5px] font-bold text-[#20160F]">
+										{s.price}
+									</div>
+									<div
+										className={`text-[11px] font-bold ${TREND_CLS[s.trend]}`}
+									>
+										{s.trendLabel}
+									</div>
+								</div>
+							</button>
+						))}
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-4">
+					<div className="rounded-2xl border border-[#EADFCB] bg-white px-5 py-[18px]">
+						<div className="flex flex-wrap items-center justify-between gap-3">
+							<div>
+								<div className="font-serif text-[19px] font-semibold text-[#20160F]">
+									{scope.name}
+								</div>
+								<span className={`text-xs font-bold ${TREND_CLS[scope.trend]}`}>
+									{scope.trendLabel}
+								</span>
+							</div>
+							<div className="text-right">
+								<div className="font-serif text-[30px] font-semibold leading-none text-[#20160F]">
+									{scope.price}
+								</div>
+								<div className="text-[11.5px] text-[#957A5C]">
+									current · per connect / month
+								</div>
+							</div>
+						</div>
+						<p className="mb-1.5 mt-1.5 text-[12.5px] text-[#957A5C]">
+							{scope.driver}
+						</p>
+						<PriceChart
+							points={scope.points}
+							labels={MONTH_LABELS}
+							floor={scope.floor}
+							ceiling={scope.ceiling}
+							todayIndex={scope.todayIndex}
+							peakIndex={scope.peakIndex}
+							harvestIndex={scope.harvestIndex}
+						/>
+					</div>
+
+					<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+						<div className="mb-3.5 flex items-center justify-between">
+							<div className="text-base font-semibold text-[#20160F]">
+								Sliding-scale controls
+							</div>
+							<Pill tone="neutral">{scope.sensitivity} sensitivity</Pill>
+						</div>
+						<div className="grid grid-cols-2 gap-x-5 gap-y-3.5">
+							<div>
+								<label
+									htmlFor="base-price"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Base price (off-season)
+								</label>
+								<input
+									id="base-price"
+									defaultValue={scope.base}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="multiplier"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Seasonal multiplier at peak
+								</label>
+								<input
+									id="multiplier"
+									defaultValue={scope.multiplier}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="floor-price"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Floor (never below)
+								</label>
+								<input
+									id="floor-price"
+									defaultValue={`KES ${scope.floor}`}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="ceiling-price"
+									className="mb-[5px] block text-xs font-semibold text-[#3F2D22]"
+								>
+									Ceiling (never above)
+								</label>
+								<input
+									id="ceiling-price"
+									defaultValue={`KES ${scope.ceiling}`}
+									className="w-full rounded-[10px] border-[1.5px] border-[#EADFCB] bg-white px-3 py-2.5 text-[13.5px] text-[#20160F]"
+								/>
+							</div>
+						</div>
+						<div className="mt-4">
+							<label
+								htmlFor="sensitivity-range"
+								className="mb-2.5 block text-xs font-semibold text-[#3F2D22]"
+							>
+								Demand sensitivity — how sharply price reacts near harvest
+							</label>
+							<input
+								id="sensitivity-range"
+								type="range"
+								min={0}
+								max={100}
+								defaultValue={72}
+								className="w-full accent-[#346B41]"
+							/>
+						</div>
+						<div className="mt-[18px] flex flex-wrap items-center justify-between gap-3">
+							<span className="text-xs text-[#957A5C]">
+								Changes take effect after the notice period.
+							</span>
+							<div className="flex gap-2">
+								<button
+									type="button"
+									className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+								>
+									Save draft
+								</button>
+								<button
+									type="button"
+									className="rounded-[10px] bg-[#346B41] px-3.5 py-2 text-[13px] font-semibold text-[#F4EAD4]"
+								>
+									Schedule change
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+						<div className="mb-3.5 flex items-center justify-between">
+							<div className="text-base font-semibold text-[#20160F]">
+								Scheduled changes
+							</div>
+							<span className="font-mono text-[11px] text-[#957A5C]">
+								Notice: 14 days
+							</span>
+						</div>
+						{scope.schedule.length > 0 ? (
+							scope.schedule.map((s) => (
+								<div
+									key={s.date}
+									className="flex items-center gap-3.5 border-t border-[#EADFCB] py-3.5 first:border-t-0"
+								>
+									<div className="w-24 shrink-0 font-mono text-xs font-semibold text-[#3F2D22]">
+										{s.date}
+									</div>
+									<div className="min-w-0 flex-1">
+										<div className="text-[13.5px] font-semibold text-[#20160F]">
+											{s.change}
+										</div>
+										<div className="text-xs text-[#957A5C]">{s.note}</div>
+									</div>
+									<Pill tone={s.status === "confirmed" ? "ok" : "watch"}>
+										{s.status}
+									</Pill>
+								</div>
+							))
+						) : (
+							<p className="py-2 text-[13px] text-[#957A5C]">
+								No upcoming changes — this rule holds until edited.
+							</p>
+						)}
+
+						<div className="mt-3.5 flex items-center gap-3.5 rounded-[13px] border border-[#E6CFA2] bg-gradient-to-r from-[#F6EAD2] to-[#F2DFBF] px-4 py-3.5 text-[#7A5320]">
+							<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#E8C98A] text-[#6D4614]">
+								<Bell size={18} aria-hidden="true" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<div className="text-[13px] font-bold">
+									{scope.stakeholders} stakeholders on notice
+								</div>
+								<div className="text-xs text-[#8A6224]">
+									Farms, buyers and agents holding this connect are notified 14
+									days before any price change.
+								</div>
+							</div>
+							<button
+								type="button"
+								className="ml-auto flex shrink-0 items-center gap-2 rounded-[10px] border border-[#E0C288] bg-white px-3.5 py-2 text-[12.5px] font-semibold text-[#7A5320]"
+							>
+								<Send size={16} aria-hidden="true" />
+								Notify now
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/connects/page.test.tsx
+++ b/src/apps/web/app/(app)/connects/page.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ConnectsPage from "./page";
+
+describe("ConnectsPage", () => {
+	it("shows held connects by default, including the unassigned-seat warning", () => {
+		render(<ConnectsPage />);
+		expect(screen.getByText("Kilele Estates")).toBeInTheDocument();
+		expect(screen.getByText("Mavuno Group")).toBeInTheDocument();
+		expect(screen.getByText("Seat is paid but unassigned")).toBeInTheDocument();
+		expect(screen.queryByText("AgriTrace Kenya")).toBeNull();
+	});
+
+	it("switches to the granted-access tab", () => {
+		render(<ConnectsPage />);
+		fireEvent.click(
+			screen.getByRole("button", { name: "Access to your farms" }),
+		);
+		expect(screen.getByText("AgriTrace Kenya")).toBeInTheDocument();
+		expect(screen.getByText("AgriTrace Sync Bot")).toBeInTheDocument();
+		expect(screen.queryByText("Kilele Estates")).toBeNull();
+	});
+});

--- a/src/apps/web/app/(app)/connects/page.tsx
+++ b/src/apps/web/app/(app)/connects/page.tsx
@@ -1,8 +1,373 @@
+"use client";
+
+import { Bot, MoreVertical, Plus } from "lucide-react";
+import { useState } from "react";
+import { Pill } from "@/components/ui/pill";
+
+type ConnectsTab = "held" | "granted";
+
+const EXP_TONE = {
+	ok: "text-[#957A5C]",
+	warn: "text-[#9C6716]",
+	bad: "text-[#9C4A24]",
+} as const;
+
+const FILL_TONE = {
+	ok: "bg-[#346B41]",
+	warn: "bg-[#C98A2B]",
+	bad: "bg-[#B4472A]",
+} as const;
+
+const STATUS_TONE = {
+	ok: "ok",
+	watch: "watch",
+} as const;
+
+interface Connect {
+	id: string;
+	farm: string;
+	ownerLine: string;
+	initials: string;
+	status: keyof typeof STATUS_TONE;
+	statusLabel: string;
+	scopes: { label: string; access: string }[];
+	assignee: {
+		kind: "user" | "agent";
+		name: string;
+		tag: string;
+		sub: string;
+		expTone: keyof typeof EXP_TONE;
+		expText: string;
+	} | null;
+	subscription: {
+		plan: string;
+		price: string;
+		cycle: string;
+		daysLeftPercent: number;
+		expTone: keyof typeof EXP_TONE;
+		daysLeftText: string;
+		expText: string;
+	};
+}
+
+const HELD_CONNECTS: Connect[] = [
+	{
+		id: "kilele",
+		farm: "Kilele Estates",
+		ownerLine: "Kilele Estates Ltd · Laikipia",
+		initials: "KE",
+		status: "ok",
+		statusLabel: "Active",
+		scopes: [
+			{ label: "Livestock", access: "View" },
+			{ label: "Milk records", access: "View + export" },
+		],
+		assignee: {
+			kind: "user",
+			name: "Grace Wanjiru",
+			tag: "Teammate",
+			sub: "grace@wakulima.co.ke",
+			expTone: "ok",
+			expText: "in 45 days",
+		},
+		subscription: {
+			plan: "Connect Basic",
+			price: "KES 1,200",
+			cycle: "per month",
+			daysLeftPercent: 40,
+			expTone: "warn",
+			daysLeftText: "12 days left",
+			expText: "Renews 20 Jul 2026",
+		},
+	},
+	{
+		id: "mavuno",
+		farm: "Mavuno Group",
+		ownerLine: "Mavuno Group · Bomet",
+		initials: "MG",
+		status: "ok",
+		statusLabel: "Active",
+		scopes: [
+			{ label: "Fields", access: "View" },
+			{ label: "Yields", access: "View" },
+		],
+		assignee: null,
+		subscription: {
+			plan: "Connect Pro",
+			price: "KES 2,500",
+			cycle: "per month",
+			daysLeftPercent: 80,
+			expTone: "ok",
+			daysLeftText: "60 days left",
+			expText: "Renews 6 Sep 2026",
+		},
+	},
+];
+
+const GRANTED_CONNECTS: Connect[] = [
+	{
+		id: "agritrace",
+		farm: "AgriTrace Kenya",
+		ownerLine: "Buyer network · access to Sunrise Poultry",
+		initials: "AT",
+		status: "watch",
+		statusLabel: "Expiring soon",
+		scopes: [
+			{ label: "Sales records", access: "View" },
+			{ label: "Inventory", access: "View" },
+		],
+		assignee: {
+			kind: "agent",
+			name: "AgriTrace Sync Bot",
+			tag: "AI agent",
+			sub: "Automated data sync",
+			expTone: "ok",
+			expText: "in 90 days",
+		},
+		subscription: {
+			plan: "Buyer Connect",
+			price: "KES 3,000",
+			cycle: "per month",
+			daysLeftPercent: 8,
+			expTone: "bad",
+			daysLeftText: "5 days left",
+			expText: "Renews 13 Jul 2026",
+		},
+	},
+];
+
 export default function ConnectsPage() {
+	const [tab, setTab] = useState<ConnectsTab>("held");
+	const connects = tab === "held" ? HELD_CONNECTS : GRANTED_CONNECTS;
+
+	const stats = [
+		{
+			v: String(HELD_CONNECTS.length + GRANTED_CONNECTS.length),
+			l: "Active connects",
+		},
+		{
+			v: String(HELD_CONNECTS.filter((c) => !c.assignee).length),
+			l: "Seats unassigned",
+		},
+		{ v: "KES 6,700", l: "Total per month" },
+		{ v: "2", l: "Expiring within 14 days" },
+	];
+
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Farm connects</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-[18px] flex flex-wrap items-center justify-between gap-3">
+				<p className="max-w-[520px] text-[13px] text-[#75583F]">
+					Connects let people and AI agents in Njoroge Holdings reach specific
+					farm datasets. Each seat can be assigned to a teammate or an agent,
+					and expires by assignment and by subscription.
+				</p>
+				<button
+					type="button"
+					className="flex items-center gap-2 rounded-[10px] bg-[#346B41] px-4 py-2.5 text-[13.5px] font-semibold text-[#F4EAD4]"
+				>
+					<Plus size={16} aria-hidden="true" />
+					{tab === "held" ? "New connect" : "Invite party"}
+				</button>
+			</div>
+
+			<div className="mb-[18px] grid grid-cols-4 gap-4">
+				{stats.map((stat) => (
+					<div
+						key={stat.l}
+						className="rounded-2xl border border-[#EADFCB] bg-white px-[18px] py-4"
+					>
+						<div className="font-serif text-2xl font-semibold leading-tight text-[#20160F]">
+							{stat.v}
+						</div>
+						<div className="mt-1 text-xs text-[#957A5C]">{stat.l}</div>
+					</div>
+				))}
+			</div>
+
+			<div className="mb-[18px] inline-flex w-max max-w-full gap-1 rounded-xl bg-[#F4EAD4] p-1">
+				<button
+					type="button"
+					onClick={() => setTab("held")}
+					className={`rounded-lg px-3.5 py-1.5 text-[13px] font-semibold ${
+						tab === "held"
+							? "bg-white text-[#20160F] shadow-[0_1px_3px_rgba(0,0,0,0.1)]"
+							: "text-[#75583F]"
+					}`}
+				>
+					Connects you hold
+				</button>
+				<button
+					type="button"
+					onClick={() => setTab("granted")}
+					className={`rounded-lg px-3.5 py-1.5 text-[13px] font-semibold ${
+						tab === "granted"
+							? "bg-white text-[#20160F] shadow-[0_1px_3px_rgba(0,0,0,0.1)]"
+							: "text-[#75583F]"
+					}`}
+				>
+					Access to your farms
+				</button>
+			</div>
+
+			<div className="flex flex-col gap-4">
+				{connects.map((c) => (
+					<div
+						key={c.id}
+						className="overflow-hidden rounded-2xl border border-[#EADFCB] bg-white"
+					>
+						<div className="flex items-center gap-3.5 px-5 pb-3.5 pt-[18px]">
+							<div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[11px] bg-gradient-to-br from-[#4A8A54] to-[#2C5A38] text-[15px] font-bold text-[#F4EAD4]">
+								{c.initials}
+							</div>
+							<div className="min-w-0 flex-1">
+								<div className="flex flex-wrap items-center gap-2">
+									<div className="font-serif text-[17px] font-semibold text-[#20160F]">
+										{c.farm}
+									</div>
+									<Pill tone={STATUS_TONE[c.status]}>{c.statusLabel}</Pill>
+								</div>
+								<div className="text-[12.5px] text-[#957A5C]">
+									{c.ownerLine}
+								</div>
+							</div>
+							<button
+								type="button"
+								aria-label={`More actions for ${c.farm}`}
+								className="flex h-9 w-9 items-center justify-center rounded-lg text-[#75583F] hover:bg-[#F4EAD4]"
+							>
+								<MoreVertical size={18} aria-hidden="true" />
+							</button>
+						</div>
+
+						<div className="px-5 pb-[18px]">
+							<div className="mb-2.5 text-[10.5px] font-bold uppercase tracking-[0.8px] text-[#957A5C]">
+								Shared scopes
+							</div>
+							<div className="flex flex-wrap gap-1.5">
+								{c.scopes.map((scope) => (
+									<span
+										key={scope.label}
+										className="inline-flex items-center gap-1.5 rounded-[9px] border border-[#EADFCB] bg-[#F4EAD4] px-2.5 py-1 text-xs font-semibold text-[#3F2D22]"
+									>
+										{scope.label}
+										<span className="rounded border border-[#EADFCB] bg-white px-1 text-[9.5px] font-bold uppercase tracking-[0.4px] text-[#957A5C]">
+											{scope.access}
+										</span>
+									</span>
+								))}
+							</div>
+						</div>
+
+						<div className="grid grid-cols-2 border-t border-[#EADFCB]">
+							<div className="p-5">
+								<div className="mb-2.5 text-[10.5px] font-bold uppercase tracking-[0.8px] text-[#957A5C]">
+									Assigned to
+								</div>
+								{c.assignee ? (
+									<>
+										<div className="flex items-center gap-2.5">
+											<div className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px] bg-gradient-to-br from-[#4A8A54] to-[#2C5A38] font-serif text-sm font-bold text-[#F4EAD4]">
+												{c.assignee.kind === "agent" ? (
+													<Bot size={18} aria-hidden="true" />
+												) : (
+													c.assignee.name
+														.split(" ")
+														.map((p) => p[0])
+														.slice(0, 2)
+														.join("")
+												)}
+											</div>
+											<div className="min-w-0">
+												<div className="flex items-center gap-2">
+													<div className="text-[13.5px] font-semibold text-[#20160F]">
+														{c.assignee.name}
+													</div>
+													<span className="rounded-full bg-[#F4EAD4] px-2 py-0.5 text-[10.5px] font-bold text-[#3F2D22]">
+														{c.assignee.tag}
+													</span>
+												</div>
+												<div className="text-xs text-[#957A5C]">
+													{c.assignee.sub}
+												</div>
+											</div>
+										</div>
+										<div
+											className={`mt-2.5 text-xs ${EXP_TONE[c.assignee.expTone]}`}
+										>
+											Assignment expires {c.assignee.expText}
+										</div>
+										<div className="mt-3.5 flex flex-wrap gap-2">
+											<button
+												type="button"
+												className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+											>
+												Reassign
+											</button>
+											<button
+												type="button"
+												className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+											>
+												Edit scopes
+											</button>
+										</div>
+									</>
+								) : (
+									<>
+										<button
+											type="button"
+											className="flex w-full items-center gap-2.5 rounded-[11px] border-[1.5px] border-dashed border-[#B49A78] px-3.5 py-3 text-left text-[13px] font-semibold text-[#3F2D22]"
+										>
+											Assign to a user or AI agent
+										</button>
+										<div className="mt-2.5 text-xs text-[#9C6716]">
+											Seat is paid but unassigned
+										</div>
+									</>
+								)}
+							</div>
+							<div className="border-l border-[#EADFCB] p-5">
+								<div className="mb-2.5 text-[10.5px] font-bold uppercase tracking-[0.8px] text-[#957A5C]">
+									Subscription
+								</div>
+								<div className="flex items-center justify-between gap-3">
+									<div className="min-w-0">
+										<div className="text-[13.5px] font-semibold text-[#20160F]">
+											{c.subscription.plan}
+										</div>
+										<div className="text-xs text-[#957A5C]">
+											{c.subscription.price} {c.subscription.cycle}
+										</div>
+									</div>
+									<div className="text-right">
+										<div
+											className={`text-[12.5px] font-bold ${EXP_TONE[c.subscription.expTone]}`}
+										>
+											{c.subscription.daysLeftText}
+										</div>
+										<div className="text-[11.5px] text-[#957A5C]">
+											{c.subscription.expText}
+										</div>
+									</div>
+								</div>
+								<div className="mt-2.5 h-1.5 overflow-hidden rounded-md bg-[#F4EAD4]">
+									<div
+										className={`h-full rounded-md ${FILL_TONE[c.subscription.expTone]}`}
+										style={{ width: `${c.subscription.daysLeftPercent}%` }}
+									/>
+								</div>
+								<div className="mt-3.5">
+									<button
+										type="button"
+										className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+									>
+										{tab === "held" ? "Change plan" : "View agreement"}
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/coop/page.test.tsx
+++ b/src/apps/web/app/(app)/coop/page.test.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CoopPage from "./page";
+
+describe("CoopPage", () => {
+	it("renders the pooled account hero and all members by default", () => {
+		render(<CoopPage />);
+		expect(screen.getByText("KES 8,940,220")).toBeInTheDocument();
+		expect(screen.getByText("Amina Njoroge")).toBeInTheDocument();
+		expect(screen.getByText("Mavuno Group")).toBeInTheDocument();
+	});
+
+	it("filters member accounts by status chip", () => {
+		render(<CoopPage />);
+		fireEvent.click(screen.getByRole("button", { name: "Flagged" }));
+		expect(screen.getByText("Mavuno Group")).toBeInTheDocument();
+		expect(screen.queryByText("Amina Njoroge")).toBeNull();
+	});
+});

--- a/src/apps/web/app/(app)/coop/page.tsx
+++ b/src/apps/web/app/(app)/coop/page.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import {
+	ArrowDownLeft,
+	ArrowUpRight,
+	Banknote,
+	FileText,
+	HandCoins,
+	UserPlus,
+	X,
+} from "lucide-react";
+import { useState } from "react";
+import { Pill } from "@/components/ui/pill";
+
+const QUICK_ACTIONS = [
+	{
+		icon: Banknote,
+		label: "Record deposit",
+		sub: "Savings, shares or milk income",
+	},
+	{
+		icon: HandCoins,
+		label: "Issue advance",
+		sub: "Against milk income or shares",
+	},
+	{
+		icon: ArrowUpRight,
+		label: "Run payout",
+		sub: "Milk income to member accounts",
+	},
+	{
+		icon: FileText,
+		label: "Export ledger",
+		sub: "CSV for audit or AGM reporting",
+	},
+] as const;
+
+const STATS = [
+	{ v: "312", l: "Active members" },
+	{ v: "KES 6.1M", l: "Total member shares" },
+	{ v: "KES 184,000", l: "Advances outstanding" },
+	{ v: "KES 1.9M", l: "Payouts this month" },
+];
+
+const CHIPS = ["All", "Active", "Dormant", "Flagged"] as const;
+
+const MEMBERS = [
+	{
+		name: "Amina Njoroge",
+		acct: "NDC-00142",
+		type: "Savings",
+		balance: "KES 84,200",
+		status: "Active",
+		statusTone: "ok" as const,
+		initials: "AN",
+	},
+	{
+		name: "Joseph Kimani",
+		acct: "NDC-00098",
+		type: "Shares",
+		balance: "KES 41,500",
+		status: "Active",
+		statusTone: "ok" as const,
+		initials: "JK",
+	},
+	{
+		name: "Grace Wanjiru",
+		acct: "NDC-00211",
+		type: "Savings",
+		balance: "KES 12,900",
+		status: "Active",
+		statusTone: "ok" as const,
+		initials: "GW",
+	},
+	{
+		name: "Samuel Njoroge",
+		acct: "NDC-00076",
+		type: "Savings",
+		balance: "KES 3,100",
+		status: "Dormant",
+		statusTone: "neutral" as const,
+		initials: "SN",
+	},
+	{
+		name: "Rift Highlands Ltd",
+		acct: "NDC-00305",
+		type: "Shares",
+		balance: "KES 210,000",
+		status: "Active",
+		statusTone: "ok" as const,
+		initials: "RH",
+	},
+	{
+		name: "Mavuno Group",
+		acct: "NDC-00027",
+		type: "Savings",
+		balance: "− KES 4,500",
+		status: "Flagged",
+		statusTone: "high" as const,
+		initials: "MG",
+	},
+];
+
+const ACTIVITY = [
+	{
+		title: "Milk payout — July round 1",
+		who: "312 members",
+		time: "8 Jul",
+		amount: "− KES 1,240,000",
+		dir: "dr" as const,
+	},
+	{
+		title: "Savings deposit",
+		who: "Amina Njoroge",
+		time: "6 Jul",
+		amount: "+ KES 5,000",
+		dir: "cr" as const,
+	},
+	{
+		title: "Share capital contribution",
+		who: "Rift Highlands Ltd",
+		time: "4 Jul",
+		amount: "+ KES 20,000",
+		dir: "cr" as const,
+	},
+	{
+		title: "Advance disbursed",
+		who: "Mavuno Group",
+		time: "2 Jul",
+		amount: "− KES 15,000",
+		dir: "dr" as const,
+	},
+	{
+		title: "Milk payout — June round 2",
+		who: "308 members",
+		time: "24 Jun",
+		amount: "− KES 1,180,000",
+		dir: "dr" as const,
+	},
+];
+
+const PENDING_ADVANCES = [
+	{
+		name: "Samuel Njoroge",
+		amount: "KES 8,000",
+		against: "Against next milk payout",
+		initials: "SN",
+	},
+	{
+		name: "Grace Wanjiru",
+		amount: "KES 5,500",
+		against: "Against savings balance",
+		initials: "GW",
+	},
+];
+
+export default function CoopPage() {
+	const [chip, setChip] = useState<(typeof CHIPS)[number]>("All");
+	const members =
+		chip === "All" ? MEMBERS : MEMBERS.filter((m) => m.status === chip);
+
+	return (
+		<div className="p-8">
+			<div className="mb-[18px] flex flex-wrap items-center justify-between gap-3">
+				<p className="max-w-[540px] text-[13px] text-[#75583F]">
+					Treasury and member accounts for the cooperative — savings, shares,
+					milk income and advances, managed like a member bank.
+				</p>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						<UserPlus size={16} aria-hidden="true" />
+						New member
+					</button>
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] bg-[#346B41] px-4 py-2.5 text-[13.5px] font-semibold text-[#F4EAD4]"
+					>
+						Run payout
+					</button>
+				</div>
+			</div>
+
+			<div className="mb-4 grid grid-cols-[1.6fr_1fr] gap-4">
+				<div className="flex min-h-[200px] flex-col justify-between rounded-[18px] bg-gradient-to-br from-[#22372C] via-[#2C5A38] to-[#3B6B46] p-6 text-[#EEF3EA]">
+					<div className="flex items-center justify-between">
+						<div>
+							<div className="text-xs tracking-[0.4px] text-[#A9C2AD]">
+								POOLED COOPERATIVE ACCOUNT
+							</div>
+							<div className="mt-1 font-serif text-[38px] font-semibold leading-none">
+								KES 8,940,220
+							</div>
+						</div>
+						<span className="rounded-lg border border-white/20 bg-white/10 px-2.5 py-1 font-mono text-xs tracking-wider text-[#BCD2BF]">
+							•••• 4021
+						</span>
+					</div>
+					<div>
+						<div className="max-w-[340px] text-[12.5px] text-[#C7DACB]">
+							Nakuru DFCS treasury float · settles member payouts and advances
+						</div>
+						<div className="mt-4 flex gap-[22px]">
+							<div>
+								<div className="text-[11px] text-[#A9C2AD]">
+									In · this month
+								</div>
+								<div className="mt-0.5 text-[14.5px] font-bold text-[#BFE6C6]">
+									+KES 2.10M
+								</div>
+							</div>
+							<div>
+								<div className="text-[11px] text-[#A9C2AD]">
+									Out · this month
+								</div>
+								<div className="mt-0.5 text-[14.5px] font-bold text-[#F2CDB4]">
+									−KES 1.72M
+								</div>
+							</div>
+							<div>
+								<div className="text-[11px] text-[#A9C2AD]">Reserve ratio</div>
+								<div className="mt-0.5 text-[14.5px] font-bold">18%</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="mb-1 text-base font-semibold text-[#20160F]">
+						Quick actions
+					</div>
+					<div className="mt-1 flex flex-col gap-2">
+						{QUICK_ACTIONS.map((action) => (
+							<button
+								key={action.label}
+								type="button"
+								className="flex w-full items-center gap-3 rounded-xl border border-[#EADFCB] bg-white px-3.5 py-3 text-left text-[#20160F] hover:border-[#B49A78] hover:bg-[#FCF8F0]"
+							>
+								<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#F4EAD4] text-[#3F2D22]">
+									<action.icon size={18} aria-hidden="true" />
+								</div>
+								<div className="min-w-0 flex-1">
+									<div className="text-[13.5px] font-semibold">
+										{action.label}
+									</div>
+									<div className="text-xs text-[#957A5C]">{action.sub}</div>
+								</div>
+							</button>
+						))}
+					</div>
+				</div>
+			</div>
+
+			<div className="mb-4 grid grid-cols-4 gap-4">
+				{STATS.map((stat) => (
+					<div
+						key={stat.l}
+						className="rounded-2xl border border-[#EADFCB] bg-white px-[18px] py-4"
+					>
+						<div className="font-serif text-2xl font-semibold leading-tight text-[#20160F]">
+							{stat.v}
+						</div>
+						<div className="mt-1 text-xs text-[#957A5C]">{stat.l}</div>
+					</div>
+				))}
+			</div>
+
+			<div className="grid grid-cols-[1.55fr_1fr] items-start gap-4">
+				<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<div className="text-base font-semibold text-[#20160F]">
+							Member accounts
+						</div>
+						<span className="font-mono text-[11px] text-[#957A5C]">
+							{MEMBERS.length} members
+						</span>
+					</div>
+					<div className="my-3.5 flex flex-wrap gap-2">
+						{CHIPS.map((c) => (
+							<button
+								key={c}
+								type="button"
+								onClick={() => setChip(c)}
+								className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
+									chip === c
+										? "border-[#346B41] bg-[#346B41] text-[#F4EAD4]"
+										: "border-[#EADFCB] bg-white text-[#75583F]"
+								}`}
+							>
+								{c}
+							</button>
+						))}
+					</div>
+					<div className="grid grid-cols-[2.1fr_1fr_1.1fr_auto] gap-3 pb-2.5 text-[10px] font-bold uppercase tracking-[0.8px] text-[#957A5C]">
+						<div>Member</div>
+						<div>Account</div>
+						<div className="text-right">Balance</div>
+						<div className="justify-self-end">Status</div>
+					</div>
+					{members.map((m) => (
+						<div
+							key={m.acct}
+							className="grid grid-cols-[2.1fr_1fr_1.1fr_auto] items-center gap-3 border-t border-[#EADFCB] py-3.5"
+						>
+							<div className="flex min-w-0 items-center gap-2.5">
+								<div className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[10px] bg-gradient-to-br from-[#4A8A54] to-[#2C5A38] text-[13px] font-bold text-[#F4EAD4]">
+									{m.initials}
+								</div>
+								<div className="min-w-0">
+									<div className="text-[13.5px] font-semibold text-[#20160F]">
+										{m.name}
+									</div>
+									<div className="font-mono text-[11.5px] text-[#957A5C]">
+										{m.acct}
+									</div>
+								</div>
+							</div>
+							<div>
+								<span className="rounded-full bg-[#F4EAD4] px-2.5 py-1 text-[11.5px] font-semibold text-[#3F2D22]">
+									{m.type}
+								</span>
+							</div>
+							<div className="text-right text-sm font-bold text-[#20160F]">
+								{m.balance}
+							</div>
+							<div className="justify-self-end">
+								<Pill tone={m.statusTone}>{m.status}</Pill>
+							</div>
+						</div>
+					))}
+				</div>
+
+				<div className="flex flex-col gap-4">
+					<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+						<div className="mb-1 flex items-center justify-between">
+							<div className="text-base font-semibold text-[#20160F]">
+								Recent activity
+							</div>
+							<button
+								type="button"
+								className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+							>
+								Statement
+							</button>
+						</div>
+						{ACTIVITY.map((txn) => (
+							<div
+								key={`${txn.title}-${txn.time}`}
+								className="flex items-center gap-3 border-t border-[#EADFCB] py-3 first:border-t-0"
+							>
+								<div
+									className={`flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[11px] ${
+										txn.dir === "cr"
+											? "bg-[#E7F0E2] text-[#2C5A38]"
+											: "bg-[#F3E7DA] text-[#9C5A24]"
+									}`}
+								>
+									{txn.dir === "cr" ? (
+										<ArrowDownLeft size={18} aria-hidden="true" />
+									) : (
+										<ArrowUpRight size={18} aria-hidden="true" />
+									)}
+								</div>
+								<div className="min-w-0 flex-1">
+									<div className="text-[13.5px] font-semibold text-[#20160F]">
+										{txn.title}
+									</div>
+									<div className="text-xs text-[#957A5C]">
+										{txn.who} · {txn.time}
+									</div>
+								</div>
+								<div
+									className={`whitespace-nowrap text-right text-[13.5px] font-bold ${
+										txn.dir === "cr" ? "text-[#2C7A4A]" : "text-[#9C5A24]"
+									}`}
+								>
+									{txn.amount}
+								</div>
+							</div>
+						))}
+					</div>
+
+					<div className="rounded-2xl border border-[#EADFCB] bg-white p-5">
+						<div className="mb-1 flex items-center justify-between">
+							<div className="text-base font-semibold text-[#20160F]">
+								Pending advances
+							</div>
+							<Pill tone="watch">{PENDING_ADVANCES.length}</Pill>
+						</div>
+						{PENDING_ADVANCES.map((p) => (
+							<div
+								key={p.name}
+								className="flex items-center gap-2.5 border-t border-[#EADFCB] py-3 first:border-t-0"
+							>
+								<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-gradient-to-br from-[#4A8A54] to-[#2C5A38] text-[12.5px] font-bold text-[#F4EAD4]">
+									{p.initials}
+								</div>
+								<div className="min-w-0 flex-1">
+									<div className="text-[13.5px] font-semibold text-[#20160F]">
+										{p.name} · {p.amount}
+									</div>
+									<div className="text-xs text-[#957A5C]">{p.against}</div>
+								</div>
+								<div className="flex items-center gap-2">
+									<button
+										type="button"
+										aria-label={`Decline advance for ${p.name}`}
+										className="flex h-[34px] w-[34px] items-center justify-center rounded-lg border border-[#EADFCB] bg-white text-[#3F2D22]"
+									>
+										<X size={16} aria-hidden="true" />
+									</button>
+									<button
+										type="button"
+										className="rounded-[10px] bg-[#346B41] px-3 py-2 text-[12.5px] font-semibold text-[#F4EAD4]"
+									>
+										Approve
+									</button>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/apps/web/app/(app)/crops/page.test.tsx
+++ b/src/apps/web/app/(app)/crops/page.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CropsPage from "./page";
+
+describe("CropsPage", () => {
+	it("renders a card for each crop", () => {
+		render(<CropsPage />);
+		expect(screen.getByText("Maize")).toBeInTheDocument();
+		expect(screen.getByText("Beans")).toBeInTheDocument();
+		expect(screen.getByText("Kale")).toBeInTheDocument();
+		expect(screen.getByText("Fallow rotation")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/crops/page.tsx
+++ b/src/apps/web/app/(app)/crops/page.tsx
@@ -1,8 +1,126 @@
+import { Pill } from "@/components/ui/pill";
+import { ProgressBar } from "@/components/ui/progress-bar";
+
+const BAND_GRADIENT = {
+	gold: "bg-gradient-to-r from-[#C98A2B] to-[#7A5A34]",
+	green: "bg-gradient-to-r from-[#4A8A54] to-[#2C5A38]",
+	lime: "bg-gradient-to-r from-[#8FBF59] to-[#5F9A3A]",
+	tan: "bg-gradient-to-r from-[#C7B489] to-[#A9906A]",
+} as const;
+
+const CROPS = [
+	{
+		name: "Maize",
+		variety: "H614",
+		area: "6.0 ha",
+		band: "gold",
+		stage: "Vegetative",
+		percent: 45,
+		fields: "Fields A1, A2",
+		season: "Long rains 2026",
+		expected: "Expected harvest: Sep 2026",
+		next: "Next: top-dress with CAN",
+	},
+	{
+		name: "Beans",
+		variety: "Rosecoco",
+		area: "3.0 ha",
+		band: "green",
+		stage: "Flowering",
+		percent: 65,
+		fields: "Fields B1, C1",
+		season: "Long rains 2026",
+		expected: "Expected harvest: Aug 2026",
+		next: "Next: pest scouting",
+	},
+	{
+		name: "Kale",
+		variety: "Collards",
+		area: "0.8 ha",
+		band: "lime",
+		stage: "Mature",
+		percent: 90,
+		fields: "Field C2",
+		season: "Continuous",
+		expected: "Expected harvest: ongoing",
+		next: "Next: weekly harvest",
+	},
+	{
+		name: "Fallow rotation",
+		variety: "Rested",
+		area: "2.6 ha",
+		band: "tan",
+		stage: "Resting",
+		percent: 20,
+		fields: "Field D1",
+		season: "Long rains 2026",
+		expected: "Expected planting: Oct 2026",
+		next: "Next: soil test",
+	},
+] as const;
+
 export default function CropsPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Crops & fields</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+				<span className="text-[13px] text-[#75583F]">
+					4 crops across 12.4 ha · Long rains 2026 season
+				</span>
+				<button
+					type="button"
+					className="flex items-center gap-2 rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+				>
+					New planting
+				</button>
+			</div>
+
+			<div className="grid grid-cols-2 gap-4">
+				{CROPS.map((crop) => (
+					<div
+						key={crop.name}
+						className="overflow-hidden rounded-2xl border border-[#EADFCB] bg-white"
+					>
+						<div className={`h-1.5 ${BAND_GRADIENT[crop.band]}`} />
+						<div className="p-5">
+							<div className="flex items-center justify-between gap-3">
+								<div>
+									<div className="text-lg font-semibold text-[#20160F]">
+										{crop.name}
+									</div>
+									<div className="text-[12.5px] text-[#75583F]">
+										{crop.variety} · {crop.area}
+									</div>
+								</div>
+								<Pill tone="ok">{crop.stage}</Pill>
+							</div>
+
+							<ProgressBar percent={crop.percent} />
+
+							<div className="flex items-center justify-between">
+								<span className="text-xs text-[#75583F]">{crop.fields}</span>
+								<span className="text-xs font-semibold text-[#20160F]">
+									{crop.season}
+								</span>
+							</div>
+
+							<div className="mt-3.5 flex items-center justify-between border-t border-[#EADFCB] pt-3.5">
+								<div className="min-w-0">
+									<div className="text-sm font-bold text-[#20160F]">
+										{crop.expected}
+									</div>
+									<div className="text-xs text-[#75583F]">{crop.next}</div>
+								</div>
+								<button
+									type="button"
+									className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+								>
+									Map
+								</button>
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/dashboard/page.test.tsx
+++ b/src/apps/web/app/(app)/dashboard/page.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import DashboardPage from "./page";
+
+describe("DashboardPage", () => {
+	it("renders the KPI cards and today's tasks", () => {
+		render(<DashboardPage />);
+		expect(screen.getByText("Active fields")).toBeInTheDocument();
+		expect(screen.getByText("Top-dress maize (Field A2)")).toBeInTheDocument();
+	});
+
+	it("marks a task as done when its checkbox is clicked", () => {
+		render(<DashboardPage />);
+		const toggle = screen.getByRole("button", {
+			name: 'Mark "Top-dress maize (Field A2)" as done',
+		});
+		fireEvent.click(toggle);
+		expect(
+			screen.getByRole("button", {
+				name: 'Mark "Top-dress maize (Field A2)" as not done',
+			}),
+		).toHaveAttribute("aria-pressed", "true");
+	});
+});

--- a/src/apps/web/app/(app)/dashboard/page.tsx
+++ b/src/apps/web/app/(app)/dashboard/page.tsx
@@ -1,8 +1,388 @@
+"use client";
+
+import { Calendar, Droplets, Sprout, Wallet } from "lucide-react";
+import { useState } from "react";
+import { Card, CardHead } from "@/components/ui/card";
+import { Pill } from "@/components/ui/pill";
+
+const KPI_ICON_BG = {
+	green: "bg-[#346B41]",
+	brown: "bg-[#7A5A34]",
+	terra: "bg-[#B46038]",
+	blue: "bg-[#4A6D7A]",
+} as const;
+
+const KPIS = [
+	{
+		icon: Sprout,
+		bg: "green",
+		value: "6",
+		label: "Active fields",
+		sub: "12.4 ha under management",
+		subCls: "text-[#957A5C]",
+	},
+	{
+		icon: Droplets,
+		bg: "brown",
+		value: "48 L",
+		label: "Milk today",
+		sub: "▲ 4% vs 7-day avg",
+		subCls: "text-[#346B41]",
+	},
+	{
+		icon: Calendar,
+		bg: "terra",
+		value: "5",
+		label: "Open tasks",
+		sub: "2 due today · 1 overdue",
+		subCls: "text-[#B46038]",
+	},
+	{
+		icon: Wallet,
+		bg: "blue",
+		value: "74,900",
+		label: "Net this month (KES)",
+		sub: "Income 107k · costs 32k",
+		subCls: "text-[#346B41]",
+	},
+] as const;
+
+const PRIORITY_DOT = {
+	high: "bg-[#B46038]",
+	normal: "bg-[#346B41]",
+	routine: "bg-[#B49A78]",
+	low: "bg-[#B9A888]",
+} as const;
+
+interface TaskRow {
+	id: string;
+	title: string;
+	ctx: string;
+	due: string;
+	priority: keyof typeof PRIORITY_DOT;
+	done: boolean;
+}
+
+const INITIAL_TASKS: TaskRow[] = [
+	{
+		id: "1",
+		title: "Top-dress maize (Field A2)",
+		ctx: "Fields & mapping",
+		due: "Today",
+		priority: "high",
+		done: false,
+	},
+	{
+		id: "2",
+		title: "Move layer hens to paddock 3",
+		ctx: "Livestock",
+		due: "Today",
+		priority: "normal",
+		done: false,
+	},
+	{
+		id: "3",
+		title: "Record milk yield",
+		ctx: "Livestock",
+		due: "Overdue",
+		priority: "high",
+		done: false,
+	},
+];
+
+const ACTIVITY = [
+	{
+		id: "1",
+		text: "Logged 48 L milk from Dairy cattle",
+		time: "2 hours ago",
+		dot: "green",
+	},
+	{
+		id: "2",
+		text: "Applied fertilizer to Field A2",
+		time: "Yesterday, 4:12 PM",
+		dot: "brown",
+	},
+	{
+		id: "3",
+		text: "Recorded KES 12,000 input cost",
+		time: "Yesterday, 11:03 AM",
+		dot: "blue",
+	},
+	{
+		id: "4",
+		text: "Pest alert acknowledged on Field B1",
+		time: "2 days ago",
+		dot: "terra",
+	},
+] as const;
+
+const ACTIVITY_DOT = {
+	green: "bg-[#346B41]",
+	brown: "bg-[#7A5A34]",
+	terra: "bg-[#B46038]",
+	blue: "bg-[#4A6D7A]",
+} as const;
+
+const WEEK = [
+	{ day: "Wed", c: "Sunny", hi: "24°", lo: "14°" },
+	{ day: "Thu", c: "Sunny", hi: "25°", lo: "15°" },
+	{ day: "Fri", c: "Partly cloudy", hi: "23°", lo: "14°" },
+	{ day: "Sat", c: "Light rain", hi: "21°", lo: "13°" },
+	{ day: "Sun", c: "Sunny", hi: "24°", lo: "14°" },
+] as const;
+
+const ALERTS = [
+	{
+		id: "1",
+		title: "Fall armyworm risk rising",
+		sub: "Field A2 · Maize",
+		tone: "high" as const,
+	},
+	{
+		id: "2",
+		title: "Low feed stock",
+		sub: "Dairy concentrate · 3 days left",
+		tone: "watch" as const,
+	},
+	{
+		id: "3",
+		title: "Soil test due",
+		sub: "Field C2 · overdue by 2 weeks",
+		tone: "watch" as const,
+	},
+];
+
+const ALERT_BAR = {
+	high: "bg-[#B46038]",
+	watch: "bg-[#B8862B]",
+} as const;
+
 export default function DashboardPage() {
+	const [tasks, setTasks] = useState(INITIAL_TASKS);
+
+	const toggleTask = (id: string) => {
+		setTasks((prev) =>
+			prev.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
+		);
+	};
+
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Dashboard</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-1 flex flex-wrap items-center justify-between gap-4">
+				<div>
+					<h1 className="text-[26px] font-semibold tracking-tight text-[#20160F]">
+						Habari, Amina 👋
+					</h1>
+					<div className="mt-0.5 text-[13.5px] text-[#75583F]">
+						Wednesday, 8 July 2026 · Mkulima Farm, Nakuru · cool dry season
+					</div>
+				</div>
+				<div className="flex items-center gap-2.5">
+					<button
+						type="button"
+						className="rounded-[10px] border border-[#EADFCB] bg-white px-4 py-2.5 text-[13.5px] font-semibold text-[#3F2D22]"
+					>
+						View tasks
+					</button>
+					<button
+						type="button"
+						className="flex items-center gap-2 rounded-[10px] bg-[#346B41] px-4 py-2.5 text-[13.5px] font-semibold text-[#F4EAD4]"
+					>
+						Log activity
+					</button>
+				</div>
+			</div>
+
+			<div className="mt-[18px] grid grid-cols-4 gap-4">
+				{KPIS.map((kpi) => (
+					<Card key={kpi.label}>
+						<div className="flex flex-col gap-2.5">
+							<div
+								className={`flex h-[38px] w-[38px] items-center justify-center rounded-[11px] text-white ${KPI_ICON_BG[kpi.bg]}`}
+							>
+								<kpi.icon size={18} aria-hidden="true" />
+							</div>
+							<div>
+								<div className="text-[27px] font-semibold leading-none text-[#20160F]">
+									{kpi.value}
+								</div>
+								<div className="text-[12.5px] font-medium text-[#75583F]">
+									{kpi.label}
+								</div>
+								<div className={`mt-0.5 text-xs ${kpi.subCls}`}>{kpi.sub}</div>
+							</div>
+						</div>
+					</Card>
+				))}
+			</div>
+
+			<div className="mt-[18px] grid grid-cols-[1.6fr_1fr] gap-[18px]">
+				<div className="flex flex-col gap-4">
+					<Card>
+						<CardHead
+							title="Today's tasks"
+							action={
+								<button
+									type="button"
+									className="text-[12.5px] font-semibold text-[#346B41]"
+								>
+									Open calendar →
+								</button>
+							}
+						/>
+						{tasks.map((task) => (
+							<div
+								key={task.id}
+								className="flex items-center gap-3 border-t border-[#EADFCB] py-3 first:border-t-0"
+							>
+								<button
+									type="button"
+									aria-pressed={task.done}
+									aria-label={`Mark "${task.title}" as ${task.done ? "not done" : "done"}`}
+									onClick={() => toggleTask(task.id)}
+									className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md border ${
+										task.done
+											? "border-[#346B41] bg-[#346B41] text-white"
+											: "border-[#B49A78] text-transparent"
+									}`}
+								>
+									<svg
+										className="h-3 w-3"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth={3}
+										aria-hidden="true"
+									>
+										<path d="M4 12l5 5L20 6" />
+									</svg>
+								</button>
+								<div
+									className={`h-2 w-2 shrink-0 rounded-full ${PRIORITY_DOT[task.priority]}`}
+								/>
+								<div className="min-w-0 flex-1">
+									<div
+										className={`text-[13.5px] font-semibold ${
+											task.done
+												? "text-[#957A5C] line-through"
+												: "text-[#20160F]"
+										}`}
+									>
+										{task.title}
+									</div>
+									<div className="text-xs text-[#957A5C]">{task.ctx}</div>
+								</div>
+								<div className="text-xs font-semibold text-[#75583F]">
+									{task.due}
+								</div>
+							</div>
+						))}
+					</Card>
+
+					<Card>
+						<CardHead
+							title="Recent activity"
+							action={
+								<button
+									type="button"
+									className="text-[12.5px] font-semibold text-[#346B41]"
+								>
+									Log new →
+								</button>
+							}
+						/>
+						{ACTIVITY.map((item) => (
+							<div
+								key={item.id}
+								className="flex items-start gap-3 border-t border-[#EADFCB] py-[11px] first:border-t-0"
+							>
+								<div
+									className={`mt-1 h-[9px] w-[9px] shrink-0 rounded-full ${ACTIVITY_DOT[item.dot]}`}
+								/>
+								<div>
+									<div className="text-[13px] font-medium text-[#20160F]">
+										{item.text}
+									</div>
+									<div className="mt-px text-[11.5px] text-[#957A5C]">
+										{item.time}
+									</div>
+								</div>
+							</div>
+						))}
+					</Card>
+				</div>
+
+				<div className="flex flex-col gap-4">
+					<Card warm>
+						<CardHead
+							title="Weather · Nakuru"
+							action={<Pill tone="neutral">Dry season</Pill>}
+						/>
+						<div className="mb-3 flex items-center gap-3.5 border-b border-[#EADFCB] pb-3.5">
+							<svg
+								className="h-11 w-11 text-[#C98A2B]"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth={1.5}
+								aria-hidden="true"
+							>
+								<circle cx="12" cy="12" r="4.5" />
+								<path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8" />
+							</svg>
+							<div>
+								<div className="font-serif text-[34px] font-semibold leading-none text-[#20160F]">
+									22°
+								</div>
+								<div className="text-xs text-[#957A5C]">
+									Sunny · light NE winds · humidity 54%
+								</div>
+							</div>
+						</div>
+						{WEEK.map((w) => (
+							<div
+								key={w.day}
+								className="flex items-center justify-between py-[7px] text-[13px]"
+							>
+								<span className="w-11 font-semibold text-[#20160F]">
+									{w.day}
+								</span>
+								<span className="flex-1 text-xs text-[#957A5C]">{w.c}</span>
+								<span className="font-semibold text-[#20160F]">{w.hi}</span>
+								<span className="w-[34px] text-right text-xs text-[#957A5C]">
+									{w.lo}
+								</span>
+							</div>
+						))}
+					</Card>
+
+					<Card>
+						<CardHead
+							title="Alerts"
+							action={<Pill tone="high">{ALERTS.length}</Pill>}
+						/>
+						{ALERTS.map((alert) => (
+							<div
+								key={alert.id}
+								className="flex gap-3 border-t border-[#EADFCB] py-3 first:border-t-0"
+							>
+								<div
+									className={`w-[3px] shrink-0 rounded-sm ${ALERT_BAR[alert.tone]}`}
+								/>
+								<div>
+									<div className="text-[13px] font-semibold text-[#20160F]">
+										{alert.title}
+									</div>
+									<div className="mt-px text-xs text-[#957A5C]">
+										{alert.sub}
+									</div>
+								</div>
+							</div>
+						))}
+					</Card>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/fields/page.test.tsx
+++ b/src/apps/web/app/(app)/fields/page.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import FieldsPage from "./page";
+
+describe("FieldsPage", () => {
+	it("shows a hint and no field panel before a plot is selected", () => {
+		render(<FieldsPage />);
+		expect(
+			screen.getByText("Tap a plot to view its soil & records"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Field A2")).toBeNull();
+	});
+
+	it("shows the field detail panel when a plot is clicked", () => {
+		render(<FieldsPage />);
+		fireEvent.click(screen.getByRole("button", { name: /A2/ }));
+		expect(screen.getByText("Field A2")).toBeInTheDocument();
+		expect(screen.getByText("Needs attention")).toBeInTheDocument();
+	});
+
+	it("switches the active records tab", () => {
+		render(<FieldsPage />);
+		fireEvent.click(screen.getByRole("button", { name: /A1/ }));
+		expect(screen.queryByText("DAP fertilizer")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Inputs" }));
+		expect(screen.getByText("DAP fertilizer")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/fields/page.tsx
+++ b/src/apps/web/app/(app)/fields/page.tsx
@@ -1,10 +1,379 @@
+"use client";
+
+import { Layers, X } from "lucide-react";
+import { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { Pill } from "@/components/ui/pill";
+
+type PlotId = "a1" | "a2" | "b1" | "c1" | "c2" | "d1";
+type RecordTab = "plantings" | "inputs" | "tasks" | "yields" | "costs";
+
+interface FieldDetail {
+	name: string;
+	sub: string;
+	status: string;
+	statusTone: "ok" | "watch" | "neutral" | "high";
+	area: string;
+	soil: string;
+	slope: string;
+	drainage: string;
+	elev: string;
+	lastSoil: string;
+}
+
+interface FieldRecord {
+	title: string;
+	sub: string;
+	meta: string;
+	ms: string;
+}
+
+const PLOTS: {
+	id: PlotId;
+	label: string;
+	sub: string;
+	position: string;
+	bg: string;
+}[] = [
+	{
+		id: "a1",
+		label: "A1",
+		sub: "Maize · 2.8 ha",
+		position: "left-[5%] top-[7%] h-[31%] w-[27%]",
+		bg: "bg-[rgba(122,150,70,0.42)]",
+	},
+	{
+		id: "a2",
+		label: "A2",
+		sub: "Maize · 3.2 ha",
+		position: "left-[34%] top-[7%] h-[34%] w-[30%]",
+		bg: "bg-[rgba(150,170,80,0.46)]",
+	},
+	{
+		id: "b1",
+		label: "B1",
+		sub: "Beans · 1.6 ha",
+		position: "left-[66%] top-[9%] h-[29%] w-[28%]",
+		bg: "bg-[rgba(70,110,60,0.5)]",
+	},
+	{
+		id: "c1",
+		label: "C1",
+		sub: "Beans · 1.4 ha",
+		position: "left-[6%] top-[44%] h-[30%] w-[24%]",
+		bg: "bg-[rgba(80,120,64,0.5)]",
+	},
+	{
+		id: "c2",
+		label: "C2",
+		sub: "Kale · 0.8 ha",
+		position: "left-[33%] top-[47%] h-[26%] w-[23%]",
+		bg: "bg-[rgba(120,168,60,0.5)]",
+	},
+	{
+		id: "d1",
+		label: "D1",
+		sub: "Fallow · 2.6 ha",
+		position: "left-[60%] top-[44%] h-[33%] w-[34%]",
+		bg: "bg-[rgba(184,150,96,0.5)]",
+	},
+];
+
+const FIELD_DETAILS: Record<PlotId, FieldDetail> = {
+	a1: {
+		name: "Field A1",
+		sub: "Maize · planted 14 Mar",
+		status: "Healthy",
+		statusTone: "ok",
+		area: "2.8",
+		soil: "Sandy loam",
+		slope: "Gentle (3–5%)",
+		drainage: "Well-drained",
+		elev: "1,847 m",
+		lastSoil: "12 Apr 2026",
+	},
+	a2: {
+		name: "Field A2",
+		sub: "Maize · planted 18 Mar",
+		status: "Needs attention",
+		statusTone: "watch",
+		area: "3.2",
+		soil: "Clay loam",
+		slope: "Gentle (2–4%)",
+		drainage: "Moderate",
+		elev: "1,852 m",
+		lastSoil: "12 Apr 2026",
+	},
+	b1: {
+		name: "Field B1",
+		sub: "Beans · planted 2 Apr",
+		status: "Healthy",
+		statusTone: "ok",
+		area: "1.6",
+		soil: "Loam",
+		slope: "Flat (0–2%)",
+		drainage: "Well-drained",
+		elev: "1,839 m",
+		lastSoil: "3 Feb 2026",
+	},
+	c1: {
+		name: "Field C1",
+		sub: "Beans · planted 5 Apr",
+		status: "Healthy",
+		statusTone: "ok",
+		area: "1.4",
+		soil: "Loam",
+		slope: "Flat (0–2%)",
+		drainage: "Well-drained",
+		elev: "1,833 m",
+		lastSoil: "3 Feb 2026",
+	},
+	c2: {
+		name: "Field C2",
+		sub: "Kale · planted 20 Apr",
+		status: "Soil test overdue",
+		statusTone: "high",
+		area: "0.8",
+		soil: "Silty clay",
+		slope: "Moderate (5–8%)",
+		drainage: "Poor",
+		elev: "1,861 m",
+		lastSoil: "18 months ago",
+	},
+	d1: {
+		name: "Field D1",
+		sub: "Fallow · resting",
+		status: "Fallow",
+		statusTone: "neutral",
+		area: "2.6",
+		soil: "Clay",
+		slope: "Moderate (4–7%)",
+		drainage: "Moderate",
+		elev: "1,858 m",
+		lastSoil: "9 Jan 2026",
+	},
+};
+
+const RECORD_TABS: { key: RecordTab; label: string }[] = [
+	{ key: "plantings", label: "Plantings" },
+	{ key: "inputs", label: "Inputs" },
+	{ key: "tasks", label: "Tasks" },
+	{ key: "yields", label: "Yields" },
+	{ key: "costs", label: "Costs" },
+];
+
+const RECORDS: Record<
+	PlotId,
+	Record<RecordTab, FieldRecord[]>
+> = Object.fromEntries(
+	PLOTS.map((p) => [
+		p.id,
+		{
+			plantings: [
+				{
+					title: `${p.sub.split(" · ")[0]} — current cycle`,
+					sub: "Planted this season",
+					meta: p.sub.split(" · ")[1] ?? "",
+					ms: "Area",
+				},
+			],
+			inputs: [
+				{
+					title: "DAP fertilizer",
+					sub: "Applied at planting",
+					meta: "50 kg",
+					ms: "Quantity",
+				},
+			],
+			tasks: [
+				{
+					title: "Top-dress with CAN",
+					sub: "Due in 6 days",
+					meta: "Pending",
+					ms: "Status",
+				},
+			],
+			yields: [
+				{
+					title: "Previous cycle yield",
+					sub: "Last harvest",
+					meta: "1.2 t/ha",
+					ms: "Yield",
+				},
+			],
+			costs: [
+				{
+					title: "Input + labor costs",
+					sub: "Season to date",
+					meta: "KES 8,400",
+					ms: "Total",
+				},
+			],
+		},
+	]),
+) as Record<PlotId, Record<RecordTab, FieldRecord[]>>;
+
 export default function FieldsPage() {
+	const [selected, setSelected] = useState<PlotId | null>(null);
+	const [tab, setTab] = useState<RecordTab>("plantings");
+
+	const field = selected ? FIELD_DETAILS[selected] : null;
+	const records = selected ? RECORDS[selected][tab] : [];
+
 	return (
-		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">
-				Fields & mapping
-			</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+		<div className="relative h-[calc(100vh-2px)] overflow-hidden">
+			<div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-[#93AC6F] via-[#7B9A56] to-[#C7B489]">
+				<div
+					className="absolute inset-0 opacity-60"
+					style={{
+						backgroundImage:
+							"repeating-linear-gradient(115deg, rgba(255,255,255,0.05) 0 2px, transparent 2px 22px), repeating-linear-gradient(25deg, rgba(0,0,0,0.04) 0 2px, transparent 2px 26px)",
+					}}
+				/>
+
+				{PLOTS.map((plot) => (
+					<button
+						key={plot.id}
+						type="button"
+						onClick={() => setSelected(plot.id)}
+						className={`absolute flex flex-col justify-between rounded-xl border-2 p-2.5 text-white shadow-[0_6px_16px_rgba(0,0,0,0.16)] transition ${plot.position} ${plot.bg} ${
+							selected === plot.id
+								? "border-[#E9C65A] shadow-[0_0_0_3px_rgba(233,198,90,0.55),0_6px_16px_rgba(0,0,0,0.2)]"
+								: "border-white/55"
+						}`}
+					>
+						<span className="text-xs font-bold [text-shadow:0_1px_2px_rgba(0,0,0,0.35)]">
+							{plot.label}
+						</span>
+						<span className="text-[10.5px] font-medium opacity-90 [text-shadow:0_1px_2px_rgba(0,0,0,0.35)]">
+							{plot.sub}
+						</span>
+					</button>
+				))}
+
+				<div className="absolute right-4 top-4 flex items-center gap-3 rounded-xl border border-[#EADFCB] bg-white px-3.5 py-2.5 shadow-[0_4px_14px_rgba(0,0,0,0.14)]">
+					<div>
+						<div className="text-[13.5px] font-bold text-[#20160F]">
+							Mkulima Farm
+						</div>
+						<div className="text-[11.5px] text-[#75583F]">
+							6 plots · 12.4 ha
+						</div>
+					</div>
+				</div>
+
+				<button
+					type="button"
+					className="absolute bottom-4 right-4 flex items-center gap-2 rounded-[11px] border border-[#EADFCB] bg-white px-3.5 py-2.5 text-[13px] font-semibold text-[#3F2D22] shadow-[0_4px_14px_rgba(0,0,0,0.14)]"
+				>
+					<Layers size={16} aria-hidden="true" />
+					Layers
+				</button>
+
+				{!selected && (
+					<div className="absolute bottom-5 left-5 flex items-center gap-2 rounded-xl bg-[#140E09]/72 px-4 py-2.5 text-[12.5px] font-semibold text-white backdrop-blur">
+						Tap a plot to view its soil & records
+					</div>
+				)}
+			</div>
+
+			{field && (
+				<div className="pointer-events-none absolute bottom-5 left-5 top-5 w-[380px]">
+					<Card>
+						<div className="pointer-events-auto max-h-full overflow-y-auto">
+							<div className="flex items-center justify-between">
+								<div>
+									<div className="text-[10px] font-bold uppercase tracking-[1.4px] text-[#957A5C]">
+										Field
+									</div>
+									<div className="font-serif text-[22px] font-semibold tracking-tight text-[#20160F]">
+										{field.name}
+									</div>
+								</div>
+								<button
+									type="button"
+									aria-label="Close field details"
+									onClick={() => setSelected(null)}
+									className="flex h-10 w-10 items-center justify-center rounded-[11px] border border-[#EADFCB] bg-white text-[#3F2D22]"
+								>
+									<X size={18} aria-hidden="true" />
+								</button>
+							</div>
+							<div className="mt-1 flex items-center gap-2.5">
+								<span className="text-[13px] text-[#75583F]">{field.sub}</span>
+								<Pill tone={field.statusTone}>{field.status}</Pill>
+							</div>
+
+							<div className="grid grid-cols-2 gap-x-[18px] gap-y-4 py-4">
+								{[
+									["Area", `${field.area} ha`],
+									["Soil", field.soil],
+									["Slope", field.slope],
+									["Drainage", field.drainage],
+									["Elevation", field.elev],
+									["Last soil test", field.lastSoil],
+								].map(([label, value]) => (
+									<div key={label}>
+										<div className="text-[10.5px] font-bold uppercase tracking-[0.8px] text-[#957A5C]">
+											{label}
+										</div>
+										<div className="mt-[3px] text-[14.5px] font-semibold text-[#20160F]">
+											{value}
+										</div>
+									</div>
+								))}
+							</div>
+
+							<div className="border-t border-[#EADFCB] pt-3.5">
+								<div className="mb-1.5 text-[11px] font-bold uppercase tracking-[1.2px] text-[#957A5C]">
+									Records derived from this field
+								</div>
+								<div className="mt-1.5 flex flex-wrap gap-1 rounded-xl bg-[#F4EAD4] p-1">
+									{RECORD_TABS.map((t) => (
+										<button
+											key={t.key}
+											type="button"
+											onClick={() => setTab(t.key)}
+											className={`rounded-[9px] px-3.5 py-1.5 text-[13px] font-semibold ${
+												tab === t.key
+													? "bg-white text-[#20160F] shadow-[0_1px_3px_rgba(0,0,0,0.1)]"
+													: "text-[#75583F]"
+											}`}
+										>
+											{t.label}
+										</button>
+									))}
+								</div>
+								<div className="mt-1">
+									{records.map((rec) => (
+										<div
+											key={rec.title}
+											className="flex justify-between gap-3 border-t border-[#EADFCB] py-3.5 first:border-t-0"
+										>
+											<div className="min-w-0">
+												<div className="text-[13.5px] font-semibold text-[#20160F]">
+													{rec.title}
+												</div>
+												<div className="mt-0.5 text-xs text-[#957A5C]">
+													{rec.sub}
+												</div>
+											</div>
+											<div className="text-right">
+												<div className="text-[13.5px] font-semibold text-[#20160F]">
+													{rec.meta}
+												</div>
+												<div className="mt-0.5 text-[11.5px] text-[#957A5C]">
+													{rec.ms}
+												</div>
+											</div>
+										</div>
+									))}
+								</div>
+							</div>
+						</div>
+					</Card>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/finances/page.test.tsx
+++ b/src/apps/web/app/(app)/finances/page.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import FinancesPage from "./page";
+
+describe("FinancesPage", () => {
+	it("renders KPI cards and recent transactions", () => {
+		render(<FinancesPage />);
+		expect(screen.getByText("Income · July")).toBeInTheDocument();
+		expect(
+			screen.getByText("Milk delivery — Nakuru Dairy Co-op"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Milk cooperative")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/finances/page.tsx
+++ b/src/apps/web/app/(app)/finances/page.tsx
@@ -1,8 +1,202 @@
+import { Card, CardHead } from "@/components/ui/card";
+
+const KPIS = [
+	{
+		label: "Income · July",
+		value: "107,000",
+		valueCls: "text-[#346B41]",
+		sub: "KES · 4 revenue streams",
+		subCls: "text-[#957A5C]",
+	},
+	{
+		label: "Expenses · July",
+		value: "32,100",
+		valueCls: "text-[#B46038]",
+		sub: "KES · feed, inputs, labour",
+		subCls: "text-[#957A5C]",
+	},
+	{
+		label: "Net · July",
+		value: "+ 74,900",
+		valueCls: "text-[#20160F]",
+		sub: "KES · margin 70%",
+		subCls: "text-[#346B41]",
+	},
+	{
+		label: "Coop balance",
+		value: "41,200",
+		valueCls: "text-[#20160F]",
+		sub: "KES · payout on 15 Jul",
+		subCls: "text-[#957A5C]",
+	},
+] as const;
+
+const TRANSACTIONS = [
+	{
+		date: "8 Jul",
+		desc: "Milk delivery — Nakuru Dairy Co-op",
+		cat: "Income · Livestock",
+		amt: "+ KES 3,216",
+		dir: "in",
+	},
+	{
+		date: "6 Jul",
+		desc: "DAP fertilizer restock",
+		cat: "Expense · Inputs",
+		amt: "− KES 9,100",
+		dir: "out",
+	},
+	{
+		date: "4 Jul",
+		desc: "Casual labour — top-dressing",
+		cat: "Expense · Labour",
+		amt: "− KES 4,500",
+		dir: "out",
+	},
+	{
+		date: "2 Jul",
+		desc: "Kale sales — market day",
+		cat: "Income · Crops",
+		amt: "+ KES 8,400",
+		dir: "in",
+	},
+	{
+		date: "29 Jun",
+		desc: "Layer feed restock",
+		cat: "Expense · Feed",
+		amt: "− KES 6,200",
+		dir: "out",
+	},
+	{
+		date: "27 Jun",
+		desc: "Egg sales",
+		cat: "Income · Livestock",
+		amt: "+ KES 5,150",
+		dir: "in",
+	},
+	{
+		date: "24 Jun",
+		desc: "Vet callout — Baraka",
+		cat: "Expense · Livestock",
+		amt: "− KES 3,500",
+		dir: "out",
+	},
+] as const;
+
+const COST_BREAKDOWN = [
+	{ label: "Feed", amount: "KES 10,500", percent: 33, color: "#7A5A34" },
+	{ label: "Labour", amount: "KES 9,000", percent: 28, color: "#B46038" },
+	{ label: "Inputs", amount: "KES 9,100", percent: 28, color: "#346B41" },
+	{ label: "Livestock", amount: "KES 3,500", percent: 11, color: "#4A6D7A" },
+] as const;
+
 export default function FinancesPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Finances</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="grid grid-cols-4 gap-4">
+				{KPIS.map((kpi) => (
+					<Card key={kpi.label}>
+						<div className="text-[12.5px] font-medium text-[#75583F]">
+							{kpi.label}
+						</div>
+						<div
+							className={`font-serif text-[27px] font-semibold leading-none ${kpi.valueCls}`}
+						>
+							{kpi.value}
+						</div>
+						<div className={`mt-0.5 text-xs ${kpi.subCls}`}>{kpi.sub}</div>
+					</Card>
+				))}
+			</div>
+
+			<div className="mt-[18px] grid grid-cols-[1.6fr_1fr] gap-[18px]">
+				<Card>
+					<CardHead
+						title="Recent transactions"
+						action={
+							<button
+								type="button"
+								className="text-[12.5px] font-semibold text-[#346B41]"
+							>
+								Add entry →
+							</button>
+						}
+					/>
+					{TRANSACTIONS.map((txn) => (
+						<div
+							key={`${txn.date}-${txn.desc}`}
+							className="flex items-center gap-3.5 border-t border-[#EADFCB] py-3 first:border-t-0"
+						>
+							<span className="w-[52px] shrink-0 font-mono text-[11.5px] text-[#957A5C]">
+								{txn.date}
+							</span>
+							<div className="min-w-0 flex-1">
+								<div className="text-[13.5px] font-semibold text-[#20160F]">
+									{txn.desc}
+								</div>
+								<div className="text-xs text-[#957A5C]">{txn.cat}</div>
+							</div>
+							<span
+								className={`ml-auto whitespace-nowrap text-[13.5px] font-bold ${
+									txn.dir === "in" ? "text-[#346B41]" : "text-[#B46038]"
+								}`}
+							>
+								{txn.amt}
+							</span>
+						</div>
+					))}
+				</Card>
+
+				<div className="flex flex-col gap-4">
+					<Card>
+						<div className="mb-3 text-base font-semibold text-[#20160F]">
+							Where costs go · July
+						</div>
+						<div className="my-2 flex h-2.5 overflow-hidden rounded-md">
+							{COST_BREAKDOWN.map((c) => (
+								<div
+									key={c.label}
+									style={{ width: `${c.percent}%`, background: c.color }}
+								/>
+							))}
+						</div>
+						<div className="mt-3 flex flex-col gap-2">
+							{COST_BREAKDOWN.map((c) => (
+								<div
+									key={c.label}
+									className="flex items-center justify-between"
+								>
+									<span className="flex items-center gap-2 text-sm text-[#20160F]">
+										<span
+											className="h-2 w-2 rounded-full"
+											style={{ background: c.color }}
+										/>
+										{c.label}
+									</span>
+									<span className="text-sm font-semibold text-[#20160F]">
+										{c.amount}
+									</span>
+								</div>
+							))}
+						</div>
+					</Card>
+
+					<Card warm>
+						<div className="mb-1.5 text-base font-semibold text-[#20160F]">
+							Milk cooperative
+						</div>
+						<div className="text-[13px] text-[#75583F]">
+							1,340 L delivered this month at KES 67/L. Next payout 15 July.
+						</div>
+						<button
+							type="button"
+							className="mt-3 rounded-[10px] bg-[#346B41] px-3 py-[7px] text-[12.5px] font-semibold text-[#F4EAD4]"
+						>
+							View production
+						</button>
+					</Card>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/inventory/page.test.tsx
+++ b/src/apps/web/app/(app)/inventory/page.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import InventoryPage from "./page";
+
+describe("InventoryPage", () => {
+	it("renders a row for each inventory item with its status", () => {
+		render(<InventoryPage />);
+		expect(screen.getByText("DAP fertilizer")).toBeInTheDocument();
+		expect(screen.getByText("Dairy concentrate")).toBeInTheDocument();
+		expect(screen.getAllByText("Reorder")).toHaveLength(2);
+	});
+});

--- a/src/apps/web/app/(app)/inventory/page.tsx
+++ b/src/apps/web/app/(app)/inventory/page.tsx
@@ -1,8 +1,114 @@
+import { Card, CardHead } from "@/components/ui/card";
+import { Pill } from "@/components/ui/pill";
+
+const FILL_TONE = {
+	ok: "bg-[#346B41]",
+	low: "bg-[#B8862B]",
+	reorder: "bg-[#B46038]",
+} as const;
+
+const STATUS_TONE = {
+	ok: "ok",
+	low: "watch",
+	reorder: "high",
+} as const;
+
+const INVENTORY = [
+	{
+		name: "DAP fertilizer",
+		qty: "12 bags of 50 kg",
+		cat: "Fertilizer",
+		percent: 70,
+		fill: "ok",
+		status: "In stock",
+	},
+	{
+		name: "CAN top-dress",
+		qty: "3 bags of 50 kg",
+		cat: "Fertilizer",
+		percent: 25,
+		fill: "low",
+		status: "Low stock",
+	},
+	{
+		name: "Maize seed (H614)",
+		qty: "40 kg",
+		cat: "Seed",
+		percent: 85,
+		fill: "ok",
+		status: "In stock",
+	},
+	{
+		name: "Dairy concentrate",
+		qty: "2 bags of 70 kg",
+		cat: "Feed",
+		percent: 12,
+		fill: "reorder",
+		status: "Reorder",
+	},
+	{
+		name: "Pesticide (cypermethrin)",
+		qty: "4 L",
+		cat: "Crop protection",
+		percent: 55,
+		fill: "ok",
+		status: "In stock",
+	},
+	{
+		name: "Layer mash",
+		qty: "1 bag of 70 kg",
+		cat: "Feed",
+		percent: 18,
+		fill: "reorder",
+		status: "Reorder",
+	},
+] as const;
+
 export default function InventoryPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Inventory</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<Card>
+				<CardHead
+					title="Farm inputs & supplies"
+					action={
+						<button
+							type="button"
+							className="flex items-center gap-2 rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+						>
+							Restock order
+						</button>
+					}
+				/>
+
+				<div className="grid grid-cols-[1.6fr_1fr_1.2fr_90px] gap-3.5 pb-2.5 text-[11px] font-bold uppercase tracking-[0.6px] text-[#957A5C]">
+					<span>Item</span>
+					<span>Category</span>
+					<span>Stock level</span>
+					<span>Status</span>
+				</div>
+
+				{INVENTORY.map((item) => (
+					<div
+						key={item.name}
+						className="grid grid-cols-[1.6fr_1fr_1.2fr_90px] items-center gap-3.5 border-t border-[#EADFCB] py-3.5"
+					>
+						<div className="min-w-0">
+							<div className="text-[13.5px] font-semibold text-[#20160F]">
+								{item.name}
+							</div>
+							<div className="text-xs text-[#957A5C]">{item.qty}</div>
+						</div>
+						<div className="text-[13px] text-[#75583F]">{item.cat}</div>
+						<div className="h-1.5 overflow-hidden rounded-full bg-[#F4EAD4]">
+							<div
+								className={`h-full rounded-full ${FILL_TONE[item.fill]}`}
+								style={{ width: `${item.percent}%` }}
+							/>
+						</div>
+						<Pill tone={STATUS_TONE[item.fill]}>{item.status}</Pill>
+					</div>
+				))}
+			</Card>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/livestock/page.test.tsx
+++ b/src/apps/web/app/(app)/livestock/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import LivestockPage from "./page";
+
+describe("LivestockPage", () => {
+	it("renders herd summaries, milk stats, and the dairy register", () => {
+		render(<LivestockPage />);
+		expect(screen.getByText("Dairy cattle")).toBeInTheDocument();
+		expect(
+			screen.getByText("Milk production · last 7 days"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Baraka")).toBeInTheDocument();
+		expect(screen.getByText("#DC-014")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/livestock/page.tsx
+++ b/src/apps/web/app/(app)/livestock/page.tsx
@@ -1,8 +1,206 @@
+import { Card, CardHead } from "@/components/ui/card";
+import { Pill } from "@/components/ui/pill";
+
+const HERDS = [
+	{
+		count: "18",
+		metric: "Milking",
+		name: "Dairy cattle",
+		sub: "Friesian-Holstein cross",
+	},
+	{
+		count: "6",
+		metric: "Healthy",
+		name: "Goats",
+		sub: "Boer cross, meat & dairy",
+	},
+	{ count: "240", metric: "Laying", name: "Layer hens", sub: "78% lay rate" },
+] as const;
+
+const MILK_BARS = [62, 70, 58, 74, 66, 80, 85] as const;
+
+const HEALTH_ALERTS = [
+	{
+		title: "CDT vaccination due — 6 goats",
+		sub: "Thursday, 10 Jul · booster",
+		high: true,
+	},
+	{ title: "Deworming — full herd", sub: "Scheduled 20 Jul", high: false },
+	{
+		title: "Baraka — pregnancy check",
+		sub: "Vet visit, due Sep calving",
+		high: false,
+	},
+] as const;
+
+const ANIMALS = [
+	{
+		name: "Baraka",
+		tag: "#DC-014",
+		breed: "Friesian-Holstein cross",
+		status: "Milking",
+		tone: "ok" as const,
+		note: "22 L/day avg",
+	},
+	{
+		name: "Furaha",
+		tag: "#DC-021",
+		breed: "Friesian-Holstein cross",
+		status: "Dry",
+		tone: "neutral" as const,
+		note: "Due to calve Sep",
+	},
+	{
+		name: "Nia",
+		tag: "#DC-009",
+		breed: "Friesian-Holstein cross",
+		status: "Milking",
+		tone: "ok" as const,
+		note: "19 L/day avg",
+	},
+	{
+		name: "Simba",
+		tag: "#GT-003",
+		breed: "Boer cross",
+		status: "Under treatment",
+		tone: "watch" as const,
+		note: "Hoof care follow-up",
+	},
+];
+
 export default function LivestockPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Livestock</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="grid grid-cols-3 gap-4">
+				{HERDS.map((herd) => (
+					<Card key={herd.name}>
+						<div className="flex items-center justify-between">
+							<div className="font-serif text-[30px] font-semibold leading-none text-[#20160F]">
+								{herd.count}
+							</div>
+							<Pill tone="ok">{herd.metric}</Pill>
+						</div>
+						<div className="mt-2 font-semibold text-[#20160F]">{herd.name}</div>
+						<div className="text-[12.5px] text-[#75583F]">{herd.sub}</div>
+					</Card>
+				))}
+			</div>
+
+			<div className="mt-[18px] grid grid-cols-[1.6fr_1fr] gap-[18px]">
+				<div className="flex flex-col gap-4">
+					<Card>
+						<CardHead
+							title="Milk production · last 7 days"
+							action={<Pill tone="ok">48 L today</Pill>}
+						/>
+						<div className="flex h-24 items-end gap-2.5 pt-2">
+							{MILK_BARS.map((h) => (
+								<div
+									key={h}
+									className="min-h-1.5 flex-1 rounded-t-md bg-[#346B41]"
+									style={{ height: `${h}%` }}
+								/>
+							))}
+						</div>
+						<div className="mt-3 flex flex-wrap justify-between gap-4 border-t border-[#EADFCB] pt-3">
+							<div>
+								<div className="font-serif text-xl font-semibold text-[#20160F]">
+									48 L
+								</div>
+								<div className="text-[11.5px] text-[#957A5C]">Today</div>
+							</div>
+							<div>
+								<div className="font-serif text-xl font-semibold text-[#20160F]">
+									46 L
+								</div>
+								<div className="text-[11.5px] text-[#957A5C]">
+									7-day average
+								</div>
+							</div>
+							<div>
+								<div className="font-serif text-xl font-semibold text-[#20160F]">
+									1,340 L
+								</div>
+								<div className="text-[11.5px] text-[#957A5C]">This month</div>
+							</div>
+							<div>
+								<div className="font-serif text-xl font-semibold text-[#20160F]">
+									KES 67/L
+								</div>
+								<div className="text-[11.5px] text-[#957A5C]">Coop rate</div>
+							</div>
+						</div>
+					</Card>
+
+					<Card>
+						<CardHead
+							title="Herd health"
+							action={
+								<button
+									type="button"
+									className="text-[12.5px] font-semibold text-[#346B41]"
+								>
+									Schedule →
+								</button>
+							}
+						/>
+						{HEALTH_ALERTS.map((alert) => (
+							<div
+								key={alert.title}
+								className="flex gap-3 border-t border-[#EADFCB] py-3 first:border-t-0"
+							>
+								<div
+									className={`w-[3px] shrink-0 rounded-sm ${alert.high ? "bg-[#B46038]" : "bg-[#B8862B]"}`}
+								/>
+								<div>
+									<div className="text-[13px] font-semibold text-[#20160F]">
+										{alert.title}
+									</div>
+									<div className="mt-px text-xs text-[#957A5C]">
+										{alert.sub}
+									</div>
+								</div>
+							</div>
+						))}
+					</Card>
+				</div>
+
+				<Card>
+					<CardHead
+						title="Dairy register"
+						action={
+							<button
+								type="button"
+								className="text-[12.5px] font-semibold text-[#346B41]"
+							>
+								Add animal →
+							</button>
+						}
+					/>
+					{ANIMALS.map((animal) => (
+						<div
+							key={animal.tag}
+							className="flex items-center gap-3 border-t border-[#EADFCB] py-3 first:border-t-0"
+						>
+							<div className="min-w-0">
+								<div className="text-[13.5px] font-semibold text-[#20160F]">
+									{animal.name}{" "}
+									<span className="rounded-md bg-[#F4EAD4] px-1.5 py-0.5 font-mono text-[11px] text-[#75583F]">
+										{animal.tag}
+									</span>
+								</div>
+								<div className="text-xs text-[#957A5C]">{animal.breed}</div>
+							</div>
+							<div className="ml-auto text-right">
+								<Pill tone={animal.tone}>{animal.status}</Pill>
+								<div className="mt-[3px] text-xs text-[#957A5C]">
+									{animal.note}
+								</div>
+							</div>
+						</div>
+					))}
+				</Card>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/reports/page.test.tsx
+++ b/src/apps/web/app/(app)/reports/page.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ReportsPage from "./page";
+
+describe("ReportsPage", () => {
+	it("renders all six report cards", () => {
+		render(<ReportsPage />);
+		expect(screen.getByText("Season summary")).toBeInTheDocument();
+		expect(screen.getByText("Milk yield trend")).toBeInTheDocument();
+		expect(screen.getByText("Cost per crop")).toBeInTheDocument();
+		expect(screen.getByText("Export data")).toBeInTheDocument();
+		expect(screen.getByText("Profit & loss")).toBeInTheDocument();
+		expect(screen.getByText("Records health")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/app/(app)/reports/page.tsx
+++ b/src/apps/web/app/(app)/reports/page.tsx
@@ -1,8 +1,163 @@
+import { Pill } from "@/components/ui/pill";
+import { ProgressBar } from "@/components/ui/progress-bar";
+
+const MILK_TREND_BARS = [70, 76, 80, 88, 92, 96] as const;
+
+const COST_PER_CROP = [
+	{ crop: "Maize", cost: "KES 23,200" },
+	{ crop: "Beans", cost: "KES 11,600" },
+	{ crop: "Kale", cost: "KES 4,300" },
+] as const;
+
 export default function ReportsPage() {
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">Reports</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<div className="mb-4 text-[13px] text-[#75583F]">
+				Season and financial summaries · Long rains 2026
+			</div>
+
+			<div className="grid grid-cols-3 items-start gap-4">
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="flex items-center justify-between">
+						<div className="text-base font-semibold text-[#20160F]">
+							Season summary
+						</div>
+						<Pill tone="ok">On track</Pill>
+					</div>
+					<div className="flex flex-wrap gap-[26px]">
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#20160F]">
+								12.4 ha
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Under crop</div>
+						</div>
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#20160F]">
+								~21.4 t
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">
+								Projected yield
+							</div>
+						</div>
+					</div>
+					<button
+						type="button"
+						className="self-start rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						Open report
+					</button>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Milk yield trend
+					</div>
+					<div className="flex h-[70px] items-end gap-2">
+						{MILK_TREND_BARS.map((h) => (
+							<div
+								key={h}
+								className="min-h-1.5 flex-1 rounded-t-md bg-[#CDB98F]"
+								style={{ height: `${h}%` }}
+							/>
+						))}
+					</div>
+					<div className="text-xs text-[#957A5C]">
+						Feb → Jul · +14% since dry season feed change
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Cost per crop
+					</div>
+					<div className="flex flex-col gap-2">
+						{COST_PER_CROP.map((row) => (
+							<div key={row.crop} className="flex items-center justify-between">
+								<span className="text-sm text-[#20160F]">{row.crop}</span>
+								<span className="text-sm font-semibold text-[#20160F]">
+									{row.cost}
+								</span>
+							</div>
+						))}
+					</div>
+					<button
+						type="button"
+						className="self-start rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						Open report
+					</button>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Export data
+					</div>
+					<div className="text-[13px] text-[#75583F]">
+						Download records for records-keeping, loans or cooperative
+						reporting.
+					</div>
+					<div className="flex gap-2">
+						<button
+							type="button"
+							className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+						>
+							CSV
+						</button>
+						<button
+							type="button"
+							className="rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+						>
+							PDF
+						</button>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-white p-5">
+					<div className="flex items-center justify-between">
+						<div className="text-base font-semibold text-[#20160F]">
+							Profit & loss
+						</div>
+						<Pill tone="ok">+70% margin</Pill>
+					</div>
+					<div className="flex flex-wrap gap-[26px]">
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#346B41]">
+								107k
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Income</div>
+						</div>
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#B46038]">
+								32k
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Costs</div>
+						</div>
+						<div>
+							<div className="font-serif text-xl font-semibold text-[#20160F]">
+								75k
+							</div>
+							<div className="text-[11.5px] text-[#957A5C]">Net</div>
+						</div>
+					</div>
+					<button
+						type="button"
+						className="self-start rounded-[10px] border border-[#EADFCB] bg-white px-3 py-[7px] text-[12.5px] font-semibold text-[#3F2D22]"
+					>
+						Open report
+					</button>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-2xl border border-[#EADFCB] bg-[#FCF8F0] p-5">
+					<div className="text-base font-semibold text-[#20160F]">
+						Records health
+					</div>
+					<div className="text-[13px] text-[#75583F]">
+						94% of activities logged this season. Keep it up for accurate
+						reports.
+					</div>
+					<ProgressBar percent={94} />
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/app/(app)/tasks/page.test.tsx
+++ b/src/apps/web/app/(app)/tasks/page.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TasksPage from "./page";
+
+describe("TasksPage", () => {
+	it("renders the week strip and the three task columns", () => {
+		render(<TasksPage />);
+		expect(screen.getByText("Week of 6–12 July 2026")).toBeInTheDocument();
+		expect(screen.getByText("Today")).toBeInTheDocument();
+		expect(screen.getByText("This week")).toBeInTheDocument();
+		expect(screen.getByText("Later")).toBeInTheDocument();
+		expect(screen.getByText("Spray Field B1 for aphids")).toBeInTheDocument();
+	});
+
+	it("marks a task done and updates its group's open count", () => {
+		render(<TasksPage />);
+		expect(screen.getByText("Today").parentElement).toHaveTextContent("3");
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: 'Mark "Spray Field B1 for aphids" as done',
+			}),
+		);
+
+		expect(screen.getByText("Today").parentElement).toHaveTextContent("2");
+	});
+});

--- a/src/apps/web/app/(app)/tasks/page.tsx
+++ b/src/apps/web/app/(app)/tasks/page.tsx
@@ -1,10 +1,228 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHead } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Pill } from "@/components/ui/pill";
+
+const WEEK = [
+	{ day: "Mon", date: 6, tasks: [] as { label: string; hi?: boolean }[] },
+	{ day: "Tue", date: 7, tasks: [{ label: "Milking" }] },
+	{
+		day: "Wed",
+		date: 8,
+		tasks: [{ label: "Spray B1", hi: true }, { label: "Top-dress A2" }],
+		today: true,
+	},
+	{ day: "Thu", date: 9, tasks: [{ label: "CDT goats", hi: true }] },
+	{ day: "Fri", date: 10, tasks: [{ label: "Harvest kale" }] },
+	{ day: "Sat", date: 11, tasks: [] },
+	{ day: "Sun", date: 12, tasks: [] },
+];
+
+const PRIORITY_DOT = {
+	high: "bg-[#B46038]",
+	normal: "bg-[#346B41]",
+	routine: "bg-[#B49A78]",
+} as const;
+
+interface TaskItem {
+	id: string;
+	title: string;
+	ctx: string;
+	due?: string;
+	priority: keyof typeof PRIORITY_DOT;
+	done: boolean;
+}
+
+const INITIAL_GROUPS: { key: string; label: string; tasks: TaskItem[] }[] = [
+	{
+		key: "today",
+		label: "Today",
+		tasks: [
+			{
+				id: "t1",
+				title: "Spray Field B1 for aphids",
+				ctx: "Fields & mapping",
+				priority: "high",
+				done: false,
+			},
+			{
+				id: "t2",
+				title: "Top-dress maize (Field A2)",
+				ctx: "Fields & mapping",
+				priority: "high",
+				done: false,
+			},
+			{
+				id: "t3",
+				title: "Morning milking",
+				ctx: "Livestock",
+				priority: "routine",
+				done: false,
+			},
+		],
+	},
+	{
+		key: "week",
+		label: "This week",
+		tasks: [
+			{
+				id: "t4",
+				title: "CDT vaccination — 6 goats",
+				ctx: "Livestock",
+				due: "Thu",
+				priority: "high",
+				done: false,
+			},
+			{
+				id: "t5",
+				title: "Harvest kale",
+				ctx: "Crops & fields",
+				due: "Fri",
+				priority: "normal",
+				done: false,
+			},
+			{
+				id: "t6",
+				title: "Record weekly milk totals",
+				ctx: "Livestock",
+				due: "Sun",
+				priority: "routine",
+				done: false,
+			},
+		],
+	},
+	{
+		key: "later",
+		label: "Later",
+		tasks: [
+			{
+				id: "t7",
+				title: "Soil test — Field C2",
+				ctx: "Fields & mapping",
+				due: "22 Jul",
+				priority: "normal",
+				done: false,
+			},
+			{
+				id: "t8",
+				title: "Order DAP fertilizer",
+				ctx: "Inventory",
+				due: "25 Jul",
+				priority: "routine",
+				done: false,
+			},
+		],
+	},
+];
+
 export default function TasksPage() {
+	const [groups, setGroups] = useState(INITIAL_GROUPS);
+
+	const toggleTask = (groupKey: string, id: string) => {
+		setGroups((prev) =>
+			prev.map((g) =>
+				g.key !== groupKey
+					? g
+					: {
+							...g,
+							tasks: g.tasks.map((t) =>
+								t.id === id ? { ...t, done: !t.done } : t,
+							),
+						},
+			),
+		);
+	};
+
+	const openCount = groups
+		.flatMap((g) => g.tasks)
+		.filter((t) => !t.done).length;
+
 	return (
 		<div className="p-8">
-			<h1 className="text-2xl font-semibold text-[#20160F]">
-				Tasks & calendar
-			</h1>
-			<p className="mt-2 text-[#6B5B45]">Coming soon.</p>
+			<Card>
+				<CardHead
+					title="Week of 6–12 July 2026"
+					action={<Pill tone="neutral">{openCount} open tasks</Pill>}
+				/>
+				<div className="mb-1.5 grid grid-cols-7 gap-2">
+					{WEEK.map((d) => (
+						<div
+							key={d.day}
+							className={`min-h-[78px] rounded-xl border p-2.5 ${
+								d.today
+									? "border-[#346B41] bg-[#EEF4EA]"
+									: "border-[#EADFCB] bg-white"
+							}`}
+						>
+							<div className="text-[11px] font-semibold text-[#957A5C]">
+								{d.day}
+							</div>
+							<div className="font-serif text-lg font-semibold text-[#20160F]">
+								{d.date}
+							</div>
+							{d.tasks.map((t) => (
+								<div
+									key={t.label}
+									className={`mt-1 truncate rounded-md px-1.5 py-0.5 text-[10.5px] font-semibold ${
+										t.hi
+											? "bg-[#F5E2D6] text-[#9C4A24]"
+											: "bg-[#F4EAD4] text-[#3F2D22]"
+									}`}
+								>
+									{t.label}
+								</div>
+							))}
+						</div>
+					))}
+				</div>
+			</Card>
+
+			<div className="mt-4 grid grid-cols-3 items-start gap-4">
+				{groups.map((group) => (
+					<Card key={group.key}>
+						<CardHead
+							title={group.label}
+							action={
+								<Pill tone={group.key === "today" ? "high" : "neutral"}>
+									{group.tasks.filter((t) => !t.done).length}
+								</Pill>
+							}
+						/>
+						{group.tasks.map((task) => (
+							<div
+								key={task.id}
+								className="flex items-center gap-3 border-t border-[#EADFCB] py-3 first:border-t-0"
+							>
+								<Checkbox
+									checked={task.done}
+									onChange={() => toggleTask(group.key, task.id)}
+									label={task.title}
+								/>
+								<div
+									className={`h-2 w-2 shrink-0 rounded-full ${PRIORITY_DOT[task.priority]}`}
+								/>
+								<div className="min-w-0">
+									<div
+										className={`text-[13.5px] font-semibold ${
+											task.done
+												? "text-[#957A5C] line-through"
+												: "text-[#20160F]"
+										}`}
+									>
+										{task.title}
+									</div>
+									<div className="text-xs text-[#957A5C]">
+										{task.ctx}
+										{task.due ? ` · ${task.due}` : ""}
+									</div>
+								</div>
+							</div>
+						))}
+					</Card>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/apps/web/components/ui/card.tsx
+++ b/src/apps/web/components/ui/card.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+interface CardProps {
+	warm?: boolean;
+	children: ReactNode;
+}
+
+export function Card({ warm, children }: CardProps) {
+	return (
+		<div
+			className={`rounded-2xl border border-[#EADFCB] p-5 ${warm ? "bg-[#FCF8F0]" : "bg-white"}`}
+		>
+			{children}
+		</div>
+	);
+}
+
+interface CardHeadProps {
+	title: string;
+	action?: ReactNode;
+}
+
+export function CardHead({ title, action }: CardHeadProps) {
+	return (
+		<div className="mb-3.5 flex items-center justify-between">
+			<div className="text-base font-semibold text-[#20160F]">{title}</div>
+			{action}
+		</div>
+	);
+}

--- a/src/apps/web/components/ui/checkbox.test.tsx
+++ b/src/apps/web/components/ui/checkbox.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Checkbox } from "./checkbox";
+
+describe("Checkbox", () => {
+	it("calls onChange with the flipped value on click", () => {
+		const onChange = vi.fn();
+		render(
+			<Checkbox checked={false} onChange={onChange} label="Spray field B1" />,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: 'Mark "Spray field B1" as done' }),
+		);
+		expect(onChange).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/apps/web/components/ui/checkbox.tsx
+++ b/src/apps/web/components/ui/checkbox.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+interface CheckboxProps {
+	checked: boolean;
+	onChange: (checked: boolean) => void;
+	label: string;
+}
+
+export function Checkbox({ checked, onChange, label }: CheckboxProps) {
+	return (
+		<button
+			type="button"
+			aria-pressed={checked}
+			aria-label={`Mark "${label}" as ${checked ? "not done" : "done"}`}
+			onClick={() => onChange(!checked)}
+			className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md border ${
+				checked
+					? "border-[#346B41] bg-[#346B41] text-white"
+					: "border-[#B49A78] text-transparent"
+			}`}
+		>
+			<svg
+				className="h-3 w-3"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={3}
+				aria-hidden="true"
+			>
+				<path d="M4 12l5 5L20 6" />
+			</svg>
+		</button>
+	);
+}

--- a/src/apps/web/components/ui/pill.test.tsx
+++ b/src/apps/web/components/ui/pill.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Pill } from "./pill";
+
+describe("Pill", () => {
+	it("renders its children", () => {
+		render(<Pill tone="high">3</Pill>);
+		expect(screen.getByText("3")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/components/ui/pill.tsx
+++ b/src/apps/web/components/ui/pill.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+const TONE_CLASSES = {
+	ok: "bg-[#E7F0E2] text-[#2C5A38]",
+	watch: "bg-[#F6ECD4] text-[#8A6316]",
+	neutral: "bg-[#EFE7D6] text-[#7A634A]",
+	high: "bg-[#F5E2D6] text-[#9C4A24]",
+} as const;
+
+interface PillProps {
+	tone: keyof typeof TONE_CLASSES;
+	children: ReactNode;
+}
+
+export function Pill({ tone, children }: PillProps) {
+	return (
+		<span
+			className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11.5px] font-semibold ${TONE_CLASSES[tone]}`}
+		>
+			{children}
+		</span>
+	);
+}

--- a/src/apps/web/components/ui/price-chart.test.tsx
+++ b/src/apps/web/components/ui/price-chart.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PriceChart } from "./price-chart";
+
+describe("PriceChart", () => {
+	it("renders an accessible image with floor and ceiling labels", () => {
+		render(
+			<PriceChart
+				points={[40, 42, 45, 50, 58, 46, 41]}
+				labels={["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul"]}
+				floor={35}
+				ceiling={60}
+				todayIndex={6}
+				peakIndex={4}
+				harvestIndex={4}
+			/>,
+		);
+		expect(screen.getByRole("img")).toBeInTheDocument();
+		expect(screen.getByText("Floor KES 35")).toBeInTheDocument();
+		expect(screen.getByText("Ceiling KES 60")).toBeInTheDocument();
+	});
+});

--- a/src/apps/web/components/ui/price-chart.tsx
+++ b/src/apps/web/components/ui/price-chart.tsx
@@ -1,0 +1,203 @@
+interface PriceChartProps {
+	points: number[];
+	labels: string[];
+	floor: number;
+	ceiling: number;
+	todayIndex: number;
+	peakIndex: number;
+	harvestIndex?: number;
+}
+
+const WIDTH = 700;
+const HEIGHT = 250;
+const X0 = 10;
+const X1 = 650;
+const Y_TOP = 20;
+const Y_BOT = 200;
+
+export function PriceChart({
+	points,
+	labels,
+	floor,
+	ceiling,
+	todayIndex,
+	peakIndex,
+	harvestIndex,
+}: PriceChartProps) {
+	const domainMin = Math.min(floor, ...points) * 0.92;
+	const domainMax = Math.max(ceiling, ...points) * 1.05;
+
+	const x = (i: number) => X0 + (i / (points.length - 1)) * (X1 - X0);
+	const y = (v: number) =>
+		Y_BOT - ((v - domainMin) / (domainMax - domainMin)) * (Y_BOT - Y_TOP);
+
+	const linePath = points
+		.map((v, i) => `${i === 0 ? "M" : "L"} ${x(i)} ${y(v)}`)
+		.join(" ");
+	const areaPath = `${linePath} L ${x(points.length - 1)} ${Y_BOT} L ${x(0)} ${Y_BOT} Z`;
+
+	return (
+		<svg
+			viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+			className="mt-1 block w-full"
+			role="img"
+			aria-label="Price over the season, with floor and ceiling bounds"
+		>
+			<line
+				x1={X0}
+				x2={X1}
+				y1={Y_TOP}
+				y2={Y_TOP}
+				stroke="#EFE7D6"
+				strokeWidth={1}
+			/>
+			<line
+				x1={X0}
+				x2={X1}
+				y1={Y_BOT}
+				y2={Y_BOT}
+				stroke="#E3D8C2"
+				strokeWidth={1}
+			/>
+
+			<path d={areaPath} fill="rgba(74,138,84,0.12)" stroke="none" />
+			<path
+				d={linePath}
+				fill="none"
+				stroke="#4A8A54"
+				strokeWidth={2.5}
+				strokeLinejoin="round"
+				strokeLinecap="round"
+			/>
+
+			<line
+				x1={X0}
+				x2={X1}
+				y1={y(ceiling)}
+				y2={y(ceiling)}
+				stroke="#B4552A"
+				strokeWidth={1}
+				strokeDasharray="4 4"
+				opacity={0.7}
+			/>
+			<text
+				x={X1}
+				y={y(ceiling)}
+				dx={-2}
+				dy={-5}
+				textAnchor="end"
+				fontSize={10}
+				fontWeight={700}
+				fill="#B4552A"
+			>
+				Ceiling KES {ceiling}
+			</text>
+
+			<line
+				x1={X0}
+				x2={X1}
+				y1={y(floor)}
+				y2={y(floor)}
+				stroke="#7A634A"
+				strokeWidth={1}
+				strokeDasharray="4 4"
+				opacity={0.55}
+			/>
+			<text
+				x={X0}
+				y={y(floor)}
+				dx={2}
+				dy={12}
+				fontSize={10}
+				fontWeight={700}
+				fill="#7A634A"
+			>
+				Floor KES {floor}
+			</text>
+
+			{harvestIndex !== undefined && (
+				<>
+					<line
+						x1={x(harvestIndex)}
+						x2={x(harvestIndex)}
+						y1={Y_TOP}
+						y2={Y_BOT}
+						stroke="#C98A2B"
+						strokeWidth={1.5}
+						strokeDasharray="3 3"
+					/>
+					<text
+						x={x(harvestIndex)}
+						y={Y_TOP}
+						dy={-4}
+						textAnchor="middle"
+						fontSize={10}
+						fontWeight={700}
+						fill="#A06A1E"
+					>
+						Harvest
+					</text>
+				</>
+			)}
+
+			<line
+				x1={x(todayIndex)}
+				x2={x(todayIndex)}
+				y1={Y_TOP}
+				y2={Y_BOT}
+				stroke="#2C5A38"
+				strokeWidth={1.5}
+			/>
+			<circle
+				cx={x(peakIndex)}
+				cy={y(points[peakIndex])}
+				r={4}
+				fill="#B4552A"
+			/>
+			<text
+				x={x(peakIndex)}
+				y={y(points[peakIndex])}
+				dx={9}
+				dy={-6}
+				fontSize={10.5}
+				fontWeight={700}
+				fill="#B4552A"
+			>
+				KES {points[peakIndex]}
+			</text>
+			<circle
+				cx={x(todayIndex)}
+				cy={y(points[todayIndex])}
+				r={5}
+				fill="#fff"
+				stroke="#2C5A38"
+				strokeWidth={2.5}
+			/>
+			<text
+				x={x(todayIndex)}
+				y={Y_BOT}
+				dy={30}
+				textAnchor="middle"
+				fontSize={10.5}
+				fontWeight={700}
+				fill="#2C5A38"
+			>
+				Today
+			</text>
+
+			{labels.map((label, i) => (
+				<text
+					key={label}
+					x={x(i)}
+					y={Y_BOT}
+					dy={16}
+					textAnchor="middle"
+					fontSize={10.5}
+					fill="#9A8570"
+				>
+					{label}
+				</text>
+			))}
+		</svg>
+	);
+}

--- a/src/apps/web/components/ui/progress-bar.test.tsx
+++ b/src/apps/web/components/ui/progress-bar.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProgressBar } from "./progress-bar";
+
+describe("ProgressBar", () => {
+	it("renders the fill at the given percent", () => {
+		const { container } = render(<ProgressBar percent={42} />);
+		const fill = container.querySelector("div > div > div");
+		expect(fill).toHaveStyle({ width: "42%" });
+	});
+
+	it("clamps out-of-range percentages", () => {
+		const { container } = render(<ProgressBar percent={150} />);
+		const fill = container.querySelector("div > div > div");
+		expect(fill).toHaveStyle({ width: "100%" });
+	});
+});

--- a/src/apps/web/components/ui/progress-bar.tsx
+++ b/src/apps/web/components/ui/progress-bar.tsx
@@ -1,0 +1,14 @@
+interface ProgressBarProps {
+	percent: number;
+}
+
+export function ProgressBar({ percent }: ProgressBarProps) {
+	return (
+		<div className="my-3 h-[7px] overflow-hidden rounded-md bg-[#F4EAD4]">
+			<div
+				className="h-full rounded-md bg-[#346B41]"
+				style={{ width: `${Math.max(0, Math.min(100, percent))}%` }}
+			/>
+		</div>
+	);
+}

--- a/src/apps/web/vitest.setup.ts
+++ b/src/apps/web/vitest.setup.ts
@@ -1,1 +1,7 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
+
+afterEach(() => {
+	cleanup();
+});


### PR DESCRIPTION
## Summary
Follow-up PR to actually land 9 screens' worth of merged work into `master`.

**What happened:** PR #73 (base: `master`, head: `wklm-62-dashboard`) merged early and closed. Everything built afterward on top of `wklm-62-dashboard` — PRs #74–82 (Fields, Crops, Livestock, Tasks, Inventory, Finances/Reports, Connects, Pricing, Coop) — targeted `wklm-62-dashboard` as their base (a stacking convention, since they all reuse `Card`/`Pill`/etc. from the Dashboard PR). Those all merged too, but *into* `wklm-62-dashboard`, not `master` — there was no open PR left to carry them onward. So `master` has been missing all 9 of those screens until now.

Meanwhile `master` independently gained the Settings screen (#71) and a dependency bump, which `wklm-62-dashboard` doesn't have — so this is a real three-way merge, not a fast-forward. GitHub's mergeability check will show if there are conflicts (I'd expect `package-lock.json` to need reconciling given the Next.js patch-version bump on `master`).

## Test plan
- [x] Each of the 9 underlying PRs was independently tested (`vitest`, `tsc --noEmit`, `biome check`) before merging.
- [ ] Re-run the full suite once this is merged/rebased onto current `master`, to catch any integration issues from the divergence (package-lock especially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)