### PR TITLE
chore: bump docker-compose default image tag to 0.9.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   farmdb:
     # No `latest` tag is published (Docker Hub immutable tags reject repushes to it) —
     # pin to the current release and bump FARMDB_IMAGE_TAG default on each release.
-    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-0.6.3}
+    image: carbonbitshq/farmdb:${FARMDB_IMAGE_TAG:-0.9.0}
     # Uncomment to build from source instead of the published image:
     # build: .
     ports:


### PR DESCRIPTION
## Summary
- Bumps \`docker-compose.yml\`'s default \`FARMDB_IMAGE_TAG\` from \`0.6.3\` to \`0.9.0\` — the latest release, which now includes the full portal build merged via PR #83 (Dashboard, Fields, Crops, Livestock, Tasks, Inventory, Finances, Reports, Settings, Connects, Pricing, Coop).

## Test plan
- [x] Verified \`0.9.0\` is published on Docker Hub (both amd64/arm64).
- [x] Ran \`docker compose up -d\` locally with this change — container starts cleanly, migrations run, and \`/\`, \`/dashboard\`, \`/settings\`, \`/coop\` all return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)